### PR TITLE
Dropping a non-existing property graph now correctly throws an error

### DIFF
--- a/duckpgq/src/duckpgq/functions/tablefunctions/create_property_graph.cpp
+++ b/duckpgq/src/duckpgq/functions/tablefunctions/create_property_graph.cpp
@@ -53,7 +53,7 @@ namespace duckdb {
     duckdb::unique_ptr<FunctionData>
     CreatePropertyGraphFunction::CreatePropertyGraphBind(ClientContext &context, TableFunctionBindInput &input,
                                                          vector<LogicalType> &return_types, vector<string> &names) {
-        names.emplace_back("success");
+        names.emplace_back("status");
         return_types.emplace_back(LogicalType::VARCHAR);
         auto lookup = context.registered_state.find("duckpgq");
         if (lookup == context.registered_state.end()) {

--- a/duckpgq/src/duckpgq/functions/tablefunctions/drop_property_graph.cpp
+++ b/duckpgq/src/duckpgq/functions/tablefunctions/drop_property_graph.cpp
@@ -8,7 +8,7 @@ namespace duckdb {
                                                                                       TableFunctionBindInput &,
                                                                                       vector<LogicalType> &return_types,
                                                                                       vector<string> &names) {
-        names.emplace_back("success");
+        names.emplace_back("status");
         return_types.emplace_back(LogicalType::VARCHAR);
         auto lookup = context.registered_state.find("duckpgq");
         if (lookup == context.registered_state.end()) {
@@ -39,7 +39,11 @@ namespace duckdb {
             throw BinderException("Registered DuckPGQ state not found");
         }
         auto duckpgq_state = (DuckPGQState *)lookup->second.get();
-        duckpgq_state->registered_property_graphs.erase(pg_info->name);
+        auto registered_pg = duckpgq_state->registered_property_graphs.find(pg_info->name);
+        if (registered_pg == duckpgq_state->registered_property_graphs.end()) {
+            throw BinderException("Property graph %s does not exist.", pg_info->name);
+        }
+        duckpgq_state->registered_property_graphs.erase(registered_pg);
     }
 }
 

--- a/duckpgq/src/duckpgq/functions/tablefunctions/drop_property_graph.cpp
+++ b/duckpgq/src/duckpgq/functions/tablefunctions/drop_property_graph.cpp
@@ -44,6 +44,7 @@ namespace duckdb {
             throw BinderException("Property graph %s does not exist.", pg_info->name);
         }
         duckpgq_state->registered_property_graphs.erase(registered_pg);
+
     }
 }
 

--- a/test/sql/basic_match.test
+++ b/test/sql/basic_match.test
@@ -180,10 +180,10 @@ FROM GRAPH_TABLE (pg
     (a:Person)-[k:Knows]->(b:Person)-[k2:Knows]->(c:Person)-[k3:Knows]->(a:Person)
     COLUMNS (a.name as a_name, b.name as b_name, c.name as c_name)
     ) study
-ORDER BY study.a_name;
+ORDER BY study.a_name, study.b_name, study.c_name;
 ----
-Daniel	Tavneet	Peter
 Daniel	Gabor	Peter
+Daniel	Tavneet	Peter
 Gabor	Peter	Daniel
 Peter	Daniel	Gabor
 Peter	Daniel	Tavneet

--- a/test/sql/basic_match.test
+++ b/test/sql/basic_match.test
@@ -179,13 +179,14 @@ FROM GRAPH_TABLE (pg
     MATCH
     (a:Person)-[k:Knows]->(b:Person)-[k2:Knows]->(c:Person)-[k3:Knows]->(a:Person)
     COLUMNS (a.name as a_name, b.name as b_name, c.name as c_name)
-    ) study;
+    ) study
+ORDER BY study.a_name;
 ----
-Peter	Daniel	Tavneet
-Peter	Daniel	Gabor
 Daniel	Tavneet	Peter
-Gabor	Peter	Daniel
 Daniel	Gabor	Peter
+Gabor	Peter	Daniel
+Peter	Daniel	Gabor
+Peter	Daniel	Tavneet
 Tavneet	Peter	Daniel
 
 statement error

--- a/test/sql/drop_property_graph.test
+++ b/test/sql/drop_property_graph.test
@@ -49,6 +49,16 @@ statement ok
 -DROP PROPERTY GRAPH pg;
 
 statement error
+-DROP PROPERTY GRAPH pg;
+----
+Binder Error: Property graph pg does not exist
+
+statement error
+-DROP PROPERTY GRAPH pgdoesntexist;
+----
+Binder Error: Property graph pgdoesntexist does not exist
+
+statement error
 -SELECT study.id
 FROM GRAPH_TABLE (pg
     MATCH

--- a/test/sql/shortest_path.test
+++ b/test/sql/shortest_path.test
@@ -55,7 +55,7 @@ query II
 ----
 Daniel	VU
 
-# Returns erroreous results https://github.com/cwida/duckpgq-extension/issues/9
+# Returns erroneous results https://github.com/cwida/duckpgq-extension/issues/9
 #query II
 #-FROM GRAPH_TABLE (pg
 #    MATCH


### PR DESCRIPTION
Dropping an already dropped property graph now results in an error