### PR TITLE
added functions to get the addresses of CSR arrays

### DIFF
--- a/duckpgq/include/duckpgq/duckpgq_functions.hpp
+++ b/duckpgq/include/duckpgq/duckpgq_functions.hpp
@@ -42,6 +42,7 @@ public:
     functions.push_back(GetScanCSREFunction());
     functions.push_back(GetScanCSRWFunction());
     functions.push_back(GetScanCSRVFunction());
+    functions.push_back(GetScanCSRPtrFunction());
     functions.push_back(GetScanPGVTableFunction());
     functions.push_back(GetScanPGVColFunction());
     functions.push_back(GetScanPGETableFunction());
@@ -72,6 +73,7 @@ private:
 
   // table functions
   static CreateTableFunctionInfo GetScanCSRVFunction();
+  static CreateTableFunctionInfo GetScanCSRPtrFunction();
   static CreateTableFunctionInfo GetScanCSREFunction();
   static CreateTableFunctionInfo GetScanCSRWFunction();
   static CreateTableFunctionInfo GetScanPGVTableFunction();

--- a/duckpgq/include/duckpgq/functions/tablefunctions/pgq_scan.hpp
+++ b/duckpgq/include/duckpgq/functions/tablefunctions/pgq_scan.hpp
@@ -29,6 +29,22 @@ public:
   int32_t csr_id;
 };
 
+struct CSRScanPtrData : public TableFunctionData {
+public:
+  static unique_ptr<FunctionData>
+  ScanCSRPtrBind(ClientContext &context, TableFunctionBindInput &input,
+               vector<LogicalType> &return_types, vector<string> &names) {
+    auto result = make_uniq<CSRScanPtrData>();
+    result->csr_id = input.inputs[0].GetValue<int32_t>();
+    return_types.emplace_back(LogicalType::UBIGINT);
+    names.emplace_back("ptr");
+    return std::move(result);
+  } 
+
+public:
+  int32_t csr_id;
+};
+
 struct CSRScanEData : public TableFunctionData {
 public:
   static unique_ptr<FunctionData>

--- a/duckpgq/src/duckpgq/functions/tablefunctions/pgq_scan.cpp
+++ b/duckpgq/src/duckpgq/functions/tablefunctions/pgq_scan.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/parser/parsed_data/create_property_graph_info.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/parser/property_graph_table.hpp"
+#include <cstdint>
 
 namespace duckdb {
 
@@ -36,6 +37,47 @@ static void ScanCSREFunction(ClientContext &context, TableFunctionInput &data_p,
   output.SetCardinality(csr->e.size());
   output.data[0].SetVectorType(VectorType::FLAT_VECTOR);
   FlatVector::SetData(output.data[0], (data_ptr_t)csr->e.data());
+}
+
+static void ScanCSRPtrFunction(ClientContext &context, TableFunctionInput &data_p,
+                             DataChunk &output) {
+  bool &gstate = ((CSRScanState &)*data_p.global_state).finished;
+
+  if (gstate) {
+    output.SetCardinality(0);
+    return;
+  }
+
+  gstate = true;
+
+  auto duckpgq_state_entry = context.registered_state.find("duckpgq");
+  if (duckpgq_state_entry == context.registered_state.end()) {
+    //! Wondering how you can get here if the extension wasn't loaded, but
+    //! leaving this check in anyways
+    throw MissingExtensionException(
+        "The DuckPGQ extension has not been loaded");
+  }
+  auto duckpgq_state =
+      reinterpret_cast<DuckPGQState *>(duckpgq_state_entry->second.get());
+  auto csr_id = data_p.bind_data->Cast<CSRScanEData>().csr_id;
+  CSR *csr = duckpgq_state->GetCSR(csr_id);
+  output.SetCardinality(5);
+  output.data[0].SetVectorType(VectorType::FLAT_VECTOR);
+  //output.data[0].SetVectorType(VectorType::CONSTANT_VECTOR);
+  auto result_data = FlatVector::GetData<uint64_t>(output.data[0]);
+  result_data[0] = (uint64_t)(csr->v);
+  result_data[1] = (uint64_t)(&(csr->e));
+  if(csr->w.size()) {
+    result_data[2] = (uint64_t)(&(csr->w));
+    result_data[4] = (uint64_t)(0);
+  } else if (csr->w_double.size()) {
+    result_data[2] = (uint64_t)(&(csr->w_double));
+    result_data[4] = (uint64_t)(1);
+  } else {
+    result_data[2] = (uint64_t)(0);
+    result_data[4] = (uint64_t)(2);
+  }
+  result_data[3] = (uint64_t)(csr->vsize);
 }
 
 static void ScanCSRVFunction(ClientContext &context, TableFunctionInput &data_p,
@@ -322,6 +364,15 @@ CreateTableFunctionInfo DuckPGQFunctions::GetScanPGVColFunction() {
   function_set.AddFunction(TableFunction(
       {LogicalType::VARCHAR, LogicalType::VARCHAR}, ScanPGVColFunction,
       PGScanVColData::ScanPGVColBind, CSRScanState::Init));
+  return CreateTableFunctionInfo(function_set);
+}
+
+CreateTableFunctionInfo DuckPGQFunctions::GetScanCSRPtrFunction() {
+  TableFunctionSet function_set("get_csr_ptr");
+
+  function_set.AddFunction(
+      TableFunction({LogicalType::INTEGER}, ScanCSRPtrFunction,
+                    CSRScanPtrData::ScanCSRPtrBind, CSRScanState::Init));
   return CreateTableFunctionInfo(function_set);
 }
 

--- a/duckpgq/src/duckpgq/functions/tablefunctions/pgq_scan.cpp
+++ b/duckpgq/src/duckpgq/functions/tablefunctions/pgq_scan.cpp
@@ -63,10 +63,17 @@ static void ScanCSRPtrFunction(ClientContext &context, TableFunctionInput &data_
   CSR *csr = duckpgq_state->GetCSR(csr_id);
   output.SetCardinality(5);
   output.data[0].SetVectorType(VectorType::FLAT_VECTOR);
-  //output.data[0].SetVectorType(VectorType::CONSTANT_VECTOR);
   auto result_data = FlatVector::GetData<uint64_t>(output.data[0]);
+  // now set the result vector
+  // the first element is the address of the vertex array
   result_data[0] = (uint64_t)(csr->v);
+  // the second element is the address of the edge array
   result_data[1] = (uint64_t)(&(csr->e));
+  // here we check the type of the weight array
+  // and set the third and fifth element
+  // the third element is the address of the weight array
+  // the fifth element is the type of the weight array
+  // 0 if the weights are integres, 1 if they are doubles, and 2 for unweighted
   if(csr->w.size()) {
     result_data[2] = (uint64_t)(&(csr->w));
     result_data[4] = (uint64_t)(0);
@@ -77,6 +84,7 @@ static void ScanCSRPtrFunction(ClientContext &context, TableFunctionInput &data_
     result_data[2] = (uint64_t)(0);
     result_data[4] = (uint64_t)(2);
   }
+  // we also need the number of elements in the vertex array, since its C-array not a vector.
   result_data[3] = (uint64_t)(csr->vsize);
 }
 

--- a/test/sql/get_csr_ptr.test
+++ b/test/sql/get_csr_ptr.test
@@ -1,0 +1,63 @@
+# name: test/sql/sqlpgq/get_csr_ptr.test
+# group: [sqlpgq]
+
+require duckpgq
+
+statement ok
+CREATE TABLE Student(id BIGINT, name VARCHAR);
+
+statement ok
+CREATE TABLE know(src BIGINT, dst BIGINT, id BIGINT);
+
+statement ok
+CREATE TABLE School(school_name VARCHAR, school_id BIGINT, school_kind BIGINT);
+
+statement ok
+INSERT INTO Student VALUES (0, 'Daniel'), (1, 'Tavneet'), (2, 'Gabor'), (3, 'Peter'), (4, 'David');
+
+statement ok
+INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (3,0, 13), (1,2, 14), (1,3, 15), (2,3, 16), (4,3, 17), (2, 4, 18);
+
+statement ok
+-CREATE PROPERTY GRAPH pg
+VERTEX TABLES (
+    Student PROPERTIES ( id, name ) LABEL Person
+    )
+EDGE TABLES (
+    know    SOURCE KEY ( src ) REFERENCES Student ( id )
+            DESTINATION KEY ( dst ) REFERENCES Student ( id )
+            PROPERTIES ( id ) LABEL Knows
+    );
+
+statement ok
+SELECT  CREATE_CSR_EDGE(
+            0,
+            (SELECT count(a.id) FROM Student a),
+            CAST (
+                (SELECT sum(CREATE_CSR_VERTEX(
+                            0,
+                            (SELECT count(a.id) FROM Student a),
+                            sub.dense_id,
+                            sub.cnt)
+                            )
+                FROM (
+                    SELECT a.rowid as dense_id, count(k.src) as cnt
+                    FROM Student a
+                    LEFT JOIN Know k ON k.src = a.id
+                    GROUP BY a.rowid) sub
+                )
+            AS BIGINT),
+            a.rowid,
+            c.rowid,
+            k.rowid) as temp
+    FROM Know k
+    JOIN student a on a.id = k.src
+    JOIN student c on c.id = k.dst;
+
+statement ok
+SELECT * FROM get_csr_ptr(0);
+
+statement error
+SELECT * FROM get_csr_ptr(10);
+----
+Error: Constraint Error: CSR not found with ID 10

--- a/test/sql/get_csr_ptr.test
+++ b/test/sql/get_csr_ptr.test
@@ -60,4 +60,4 @@ SELECT * FROM get_csr_ptr(0);
 statement error
 SELECT * FROM get_csr_ptr(10);
 ----
-Error: Constraint Error: CSR not found with ID 10
+Constraint Error: CSR not found with ID 10


### PR DESCRIPTION
This PR adds a new table function to get the addresses of CSR arrays, which is the base to enable memory sharing of CSR arrays.