### PR TITLE
Adding a projected snb test

### DIFF
--- a/duckpgq/src/duckpgq/functions/tablefunctions/match.cpp
+++ b/duckpgq/src/duckpgq/functions/tablefunctions/match.cpp
@@ -48,9 +48,9 @@ void PGQMatchFunction::CheckInheritance(
   const auto itr = std::find(tableref->sub_labels.begin(),
                              tableref->sub_labels.end(), element->label);
 
-  const auto idx_of_element = std::distance(tableref->sub_labels.begin(), itr);
+  const auto idx_of_label = std::distance(tableref->sub_labels.begin(), itr);
   auto constant_expression_idx_label = make_uniq<ConstantExpression>(
-      Value::INTEGER(static_cast<int32_t>(idx_of_element)));
+      Value::INTEGER(static_cast<int32_t>(idx_of_label)));
 
   vector<unique_ptr<ParsedExpression>> power_of_children;
   power_of_children.push_back(std::move(constant_expression_two));
@@ -58,7 +58,7 @@ void PGQMatchFunction::CheckInheritance(
   auto power_of_term =
       make_uniq<FunctionExpression>("power", std::move(power_of_children));
   auto bigint_cast =
-      make_uniq<CastExpression>(LogicalType::BIGINT, std::move(power_of_term));
+      make_uniq<CastExpression>(LogicalType::INTEGER, std::move(power_of_term));
   auto subcategory_colref = make_uniq<ColumnRefExpression>(
       tableref->discriminator, element->variable_binding);
   vector<unique_ptr<ParsedExpression>> and_children;
@@ -69,7 +69,7 @@ void PGQMatchFunction::CheckInheritance(
       make_uniq<FunctionExpression>("&", std::move(and_children));
 
   auto constant_expression_idx_label_comparison = make_uniq<ConstantExpression>(
-      Value::INTEGER(static_cast<int32_t>(idx_of_element + 1)));
+      Value::INTEGER(static_cast<int32_t>(pow(2, idx_of_label))));
 
   auto subset_compare = make_uniq<ComparisonExpression>(
       ExpressionType::COMPARE_EQUAL, std::move(and_expression),

--- a/test/sql/pattern-matching/inheritance_support.test
+++ b/test/sql/pattern-matching/inheritance_support.test
@@ -13,10 +13,10 @@ statement ok
 CREATE TABLE Organisation(name VARCHAR, id BIGINT, mask BIGINT);
 
 statement ok
-CREATE TABLE Company(name VARCHAR, id BIGINT, kind VARCHAR);
+CREATE TABLE Company(name VARCHAR, id BIGINT, mask VARCHAR);
 
 statement ok
-CREATE TABLE University(name VARCHAR, id BIGINT, kind VARCHAR);
+CREATE TABLE University(name VARCHAR, id BIGINT, mask VARCHAR);
 
 statement ok
 CREATE TABLE worksAt(personId BIGINT, organisationId BIGINT);
@@ -28,10 +28,10 @@ statement ok
 INSERT INTO worksAt VALUES (0,1), (0,2), (0,3), (3,0), (1,2), (1,3), (2,3), (4,3);
 
 statement ok
-INSERT INTO University VALUES ('VU', 0, 1), ('UVA', 1, 1);
+INSERT INTO University VALUES ('VU', 0, 2), ('UvA', 1, 2);
 
 statement ok
-INSERT INTO Company VALUES ('EY', 2, 2), ('CWI', 3, 2);
+INSERT INTO Company VALUES ('EY', 2, 4), ('CWI', 3, 4);
 
 statement ok
 INSERT INTO Organisation (SELECT * from university union select * from company);
@@ -55,7 +55,7 @@ FROM GRAPH_TABLE(pg
     COLUMNS (p.id, p.name, u.id, u.name)
     ) result
 ----
-0	Daniel	1	UVA
+0	Daniel	1	UvA
 0	Daniel	2	EY
 0	Daniel	3	CWI
 3	Peter	0	VU
@@ -64,38 +64,38 @@ FROM GRAPH_TABLE(pg
 2	Gabor	3	CWI
 4	David	3	CWI
 
-query IIII
+query IIIII
 -SELECT *
 FROM GRAPH_TABLE(pg
     MATCH (p:Person)-[w:worksAt]->(u:ORGANISATION)
-    COLUMNS (p.id, p.name, u.id, u.name)
+    COLUMNS (p.id, p.name, u.id, u.name, u.mask)
     ) result
 ----
-0	Daniel	1	UVA
-0	Daniel	2	EY
-0	Daniel	3	CWI
-3	Peter	0	VU
-1	Tavneet	2	EY
-1	Tavneet	3	CWI
-2	Gabor	3	CWI
-4	David	3	CWI
+0	Daniel	1	UvA	2
+0	Daniel	2	EY	4
+0	Daniel	3	CWI	4
+3	Peter	0	VU	2
+1	Tavneet	2	EY	4
+1	Tavneet	3	CWI	4
+2	Gabor	3	CWI	4
+4	David	3	CWI	4
 
 
 query IIII
 -SELECT *
 FROM GRAPH_TABLE(pg
     MATCH (p:Person)-[w:worksAt]->(u:university)
-    COLUMNS (p.id, p.name, u.id, u.name)
+    COLUMNS (p.id, p.name, u.id, u.name, u.mask)
     ) result
 ----
-0	Daniel	1	UVA
+0	Daniel	1	UvA
 3	Peter	0	VU
 
 query IIII
 -SELECT *
 FROM GRAPH_TABLE(pg
     MATCH (p:Person)-[w:worksAt]->(u:company)
-    COLUMNS (p.id, p.name, u.id, u.name)
+    COLUMNS (p.id, p.name, u.id, u.name, u.mask)
     ) result
 ----
 0	Daniel	3	CWI
@@ -127,7 +127,7 @@ FROM GRAPH_TABLE(pg
     COLUMNS (p.id, p.name, u.id, u.name)
     ) result
 ----
-1	UVA	0	Daniel
+1	UvA	0	Daniel
 2	EY	0	Daniel
 3	CWI	0	Daniel
 0	VU	3	Peter
@@ -140,10 +140,10 @@ query IIII
 -SELECT *
 FROM GRAPH_TABLE(pg
     MATCH (p:university)<-[w:worksAt]-(u:person)
-    COLUMNS (p.id, p.name, u.id, u.name)
+    COLUMNS (p.id, p.name, u.id, u.mask)
     ) result
 ----
-1	UVA	0	Daniel
+1	UvA	0	Daniel
 0	VU	3	Peter
 
 statement ok

--- a/test/sql/pattern-matching/inheritance_support.test
+++ b/test/sql/pattern-matching/inheritance_support.test
@@ -25,13 +25,13 @@ statement ok
 INSERT INTO Person VALUES (0, 'Daniel'), (1, 'Tavneet'), (2, 'Gabor'), (3, 'Peter'), (4, 'David');
 
 statement ok
-INSERT INTO worksAt VALUES (0,1), (0,2), (0,3), (3,0), (1,2), (1,3), (2,3), (4,3);
+INSERT INTO worksAt VALUES (0,1), (0,2), (0,3), (1,2), (1,3), (2,3), (3,0), (4,3);
 
 statement ok
-INSERT INTO University VALUES ('VU', 0, 2), ('UvA', 1, 2);
+INSERT INTO University VALUES ('VU', 0, 1), ('UvA', 1, 1);
 
 statement ok
-INSERT INTO Company VALUES ('EY', 2, 4), ('CWI', 3, 4);
+INSERT INTO Company VALUES ('EY', 2, 2), ('CWI', 3, 2);
 
 statement ok
 INSERT INTO Organisation (SELECT * from university union select * from company);
@@ -58,10 +58,10 @@ FROM GRAPH_TABLE(pg
 0	Daniel	1	UvA
 0	Daniel	2	EY
 0	Daniel	3	CWI
-3	Peter	0	VU
 1	Tavneet	2	EY
 1	Tavneet	3	CWI
 2	Gabor	3	CWI
+3	Peter	0	VU
 4	David	3	CWI
 
 query IIIII
@@ -71,39 +71,37 @@ FROM GRAPH_TABLE(pg
     COLUMNS (p.id, p.name, u.id, u.name, u.mask)
     ) result
 ----
-0	Daniel	1	UvA	2
-0	Daniel	2	EY	4
-0	Daniel	3	CWI	4
-3	Peter	0	VU	2
-1	Tavneet	2	EY	4
-1	Tavneet	3	CWI	4
-2	Gabor	3	CWI	4
-4	David	3	CWI	4
+0	Daniel	1	UvA	1
+0	Daniel	2	EY	2
+0	Daniel	3	CWI	2
+1	Tavneet	2	EY	2
+1	Tavneet	3	CWI	2
+2	Gabor	3	CWI	2
+3	Peter	0	VU	1
+4	David	3	CWI	2
 
-
-query IIII
--SELECT *
-FROM GRAPH_TABLE(pg
+query IIIII
+-FROM GRAPH_TABLE(pg
     MATCH (p:Person)-[w:worksAt]->(u:university)
     COLUMNS (p.id, p.name, u.id, u.name, u.mask)
     ) result
 ----
-0	Daniel	1	UvA
-3	Peter	0	VU
+0	Daniel	1	UvA	1
+3	Peter	0	VU	1
 
-query IIII
+query IIIII
 -SELECT *
 FROM GRAPH_TABLE(pg
     MATCH (p:Person)-[w:worksAt]->(u:company)
     COLUMNS (p.id, p.name, u.id, u.name, u.mask)
     ) result
 ----
-0	Daniel	3	CWI
-1	Tavneet	3	CWI
-2	Gabor	3	CWI
-4	David	3	CWI
-0	Daniel	2	EY
-1	Tavneet	2	EY
+0	Daniel	3	CWI	2
+1	Tavneet	3	CWI	2
+2	Gabor	3	CWI	2
+4	David	3	CWI	2
+0	Daniel	2	EY	2
+1	Tavneet	2	EY	2
 
 # Should work with different capitalization
 query IIII
@@ -130,21 +128,21 @@ FROM GRAPH_TABLE(pg
 1	UvA	0	Daniel
 2	EY	0	Daniel
 3	CWI	0	Daniel
-0	VU	3	Peter
 2	EY	1	Tavneet
 3	CWI	1	Tavneet
 3	CWI	2	Gabor
+0	VU	3	Peter
 3	CWI	4	David
 
 query IIII
 -SELECT *
 FROM GRAPH_TABLE(pg
-    MATCH (p:university)<-[w:worksAt]-(u:person)
-    COLUMNS (p.id, p.name, u.id, u.mask)
+    MATCH (u:university)<-[w:worksAt]-(p:person)
+    COLUMNS (p.id, p.name, u.name, u.mask)
     ) result
 ----
-1	UvA	0	Daniel
-0	VU	3	Peter
+0	Daniel	UvA	1
+3	Peter	VU	1
 
 statement ok
 -drop property graph pg;

--- a/test/sql/snb/snb-projected.test
+++ b/test/sql/snb/snb-projected.test
@@ -1,0 +1,107 @@
+require duckpgq
+
+statement ok
+import database 'duckdb-pgq/data/SNB1-projected|';
+
+statement ok
+.read 'duckdb-pgq/data/SNB1-projected/schema.sql';
+
+statement ok
+-CREATE PROPERTY GRAPH snb_projected
+VERTEX TABLES (
+    Forum LABEL Forum,
+    Message LABEL Message IN Subcategory(Comment, Post),
+    Organisation LABEL Organisation IN Subcategory(University, Company),
+    Person LABEL Person,
+    Place LABEL Place IN Subcategory(Continent, Country, City),
+    Tag LABEL Tag,
+    TagClass LABEL TagClass
+    )
+EDGE TABLES (
+    Comment_hasCreator_Person   SOURCE KEY (CommentId) REFERENCES Message (id)
+                            DESTINATION KEY (PersonId) REFERENCES Person (id)
+                            LABEL Comment_hasCreator,
+    Comment_hasTag_Tag      SOURCE KEY (CommentId) REFERENCES Message (id)
+                            DESTINATION KEY (TagId) REFERENCES Tag (id)
+                            LABEL Comment_hasTag,
+    Comment_isLocatedIn_Country     SOURCE KEY (CommentId) REFERENCES Message (id)
+                            DESTINATION KEY (CountryId) REFERENCES Tag (id)
+                            LABEL Comment_isLocatedIn,
+    Comment_replyOf_Comment SOURCE KEY (Comment1Id) REFERENCES Message (id)
+                            DESTINATION KEY (Comment2Id) REFERENCES Message (id)
+                            LABEL replyOf_Comment,
+    Comment_replyOf_Post    SOURCE KEY (CommentId) REFERENCES Message (id)
+                            DESTINATION KEY (PostId) REFERENCES Message (id)
+                            LABEL replyOf_Post,
+    Forum_containerOf_Post  SOURCE KEY (ForumId) REFERENCES Forum (id)
+                            DESTINATION KEY (PostId) REFERENCES Message (id)
+                            LABEL containerOf,
+    Forum_hasMember_Person  SOURCE KEY (ForumId) REFERENCES Forum (id)
+                            DESTINATION KEY (PersonId) REFERENCES Person (id)
+                            LABEL hasMember,
+    Forum_hasModerator_Person   SOURCE KEY (ForumId) REFERENCES Forum (id)
+                            DESTINATION KEY (PersonId) REFERENCES Person (id)
+                            LABEL hasModerator,
+    Forum_hasTag_Tag        SOURCE KEY (ForumId) REFERENCES Forum (id)
+                            DESTINATION KEY (TagId) REFERENCES Tag (id)
+                            LABEL Forum_hasTag,
+    Organisation_isLocatedIn_Place  SOURCE KEY (OrganisationId) REFERENCES Organisation (id)
+                            DESTINATION KEY (PlaceId) REFERENCES Place (id)
+                            LABEL Organisation_isLocatedIn,
+    Person_hasInterest_Tag  SOURCE KEY (PersonId) REFERENCES Person (id)
+                            DESTINATION KEY (interestId) REFERENCES Tag (id)
+                            LABEL hasInterest,
+    Person_isLocatedIn_City     SOURCE KEY (PersonId) REFERENCES Person (id)
+                            DESTINATION KEY (CityId) REFERENCES Place (id)
+                            LABEL Person_isLocatedIn,
+    Person_knows_person     SOURCE KEY (Person1Id) REFERENCES Person (id)
+                            DESTINATION KEY (Person2Id) REFERENCES Person (id)
+                            LABEL Knows,
+    Person_likes_Comment    SOURCE KEY (PersonId) REFERENCES Person (id)
+                            DESTINATION KEY (CommentId) REFERENCES Message (id)
+                            LABEL likes_Comment,
+    Person_likes_Post       SOURCE KEY (PersonId) REFERENCES Person (id)
+                            DESTINATION KEY (PostId) REFERENCES Message (id)
+                            LABEL likes_Post,
+    Person_studyAt_University   SOURCE KEY (PersonId) REFERENCES Person (id)
+                            DESTINATION KEY (UniversityId) REFERENCES Organisation (id)
+                            LABEL studyAt,
+    Person_workAt_Company   SOURCE KEY (PersonId) REFERENCES Person (id)
+                            DESTINATION KEY (CompanyId) REFERENCES Organisation (id)
+                            LABEL workAt,
+    Place_isPartOf_Place    SOURCE KEY (Place1Id) REFERENCES Place (id)
+                            DESTINATION KEY (Place2Id) REFERENCES Place (id)
+                            LABEL isPartOf,
+    Post_hasCreator_Person  SOURCE KEY (PostId) REFERENCES Message (id)
+                            DESTINATION KEY (PersonId) REFERENCES Person (id)
+                            LABEL Post_hasCreator,
+    Message_hasCreator_Person   SOURCE KEY (MessageId) REFERENCES Message (id)
+                            DESTINATION KEY (PersonId) REFERENCES Person (id)
+                            LABEL Message_hasCreator,
+    Message_hasTag_Tag      SOURCE KEY (MessageId) REFERENCES Message (id)
+                            DESTINATION KEY (TagId) REFERENCES Tag (id)
+                            LABEL Message_hasTag,
+    Message_isLocatedIn_Country SOURCE KEY (MessageId) REFERENCES Message (id)
+                            DESTINATION KEY (CountryId) REFERENCES Place (id)
+                            LABEL Message_isLocatedIn,
+    Post_hasTag_Tag         SOURCE KEY (PostId) REFERENCES Message (id)
+                            DESTINATION KEY (TagId) REFERENCES Tag (id)
+                            LABEL Post_hasTag,
+    Post_isLocatedIn_Country    SOURCE KEY (PostId) REFERENCES Message (id)
+                            DESTINATION KEY (CountryId) REFERENCES Place (id)
+                            LABEL Post_isLocatedIn,
+    Tag_hasType_TagClass    SOURCE KEY (TagId) REFERENCES Tag (id)
+                            DESTINATION KEY (TagClassId) REFERENCES TagClass (id)
+                            LABEL hasType,
+    TagClass_isSubClassOf_TagClass  SOURCE KEY (TagClass1Id) REFERENCES TagClass (id)
+                            DESTINATION KEY (TagClass2Id) REFERENCES TagClass (id)
+                            LABEL isSubClassOf
+    );
+
+# IS2
+query IIIIIIII
+-FROM GRAPH_TABLE (snb_projected
+     MATCH (a:person where a.id = 4026)-[i:Person_isLocatedIn]->(c:City)
+     COLUMNS(a.firstName, a.lastName, a.birthday, a.locationIP, a.browserUsed, c.id, a.gender, a.creationDate)
+     ) tmp;
+----

--- a/test/sql/snb/snb-projected.test
+++ b/test/sql/snb/snb-projected.test
@@ -4,9 +4,6 @@ statement ok
 import database 'duckdb-pgq/data/SNB1-projected|';
 
 statement ok
-.read 'duckdb-pgq/data/SNB1-projected/schema.sql';
-
-statement ok
 -CREATE PROPERTY GRAPH snb_projected
 VERTEX TABLES (
     Forum LABEL Forum,

--- a/test/sql/snb/snb-projected.test_slow
+++ b/test/sql/snb/snb-projected.test_slow
@@ -102,3 +102,4 @@ query IIIIIIII
      COLUMNS(a.firstName, a.lastName, a.birthday, a.locationIP, a.browserUsed, c.id, a.gender, a.creationDate)
      ) tmp;
 ----
+Ivan	Dobrunov	1988-10-21	31.28.20.134	Firefox	865	female	2010-02-09 17:26:35.413


### PR DESCRIPTION
Fixing the inheritance for more than 2 sub categories. 
Now checks properly if &(2^`idx_sublabel`) == 2^`idx_sublabel`