### PR TITLE
Change parser to make EdgeTableClause optional

### DIFF
--- a/test/sql/create_pg/optional_edge_table_clause.test
+++ b/test/sql/create_pg/optional_edge_table_clause.test
@@ -8,6 +8,16 @@ import database 'duckdb-pgq/data/SNB0.003';
 
 statement ok
 -CREATE PROPERTY GRAPH snb
-VERTEX TABLES (Message);
+VERTEX TABLES (Message, person);
 
 statement ok
+-FROM GRAPH_TABLE (snb
+    MATCH (m:Message)
+    COLUMNS (*)
+    ) tmp
+
+statement error
+-FROM GRAPH_TABLE (snb
+    MATCH (p:Person)-[k:Knows]->(p2:Person)
+    COLUMNS (*)
+    ) tmp

--- a/test/sql/create_pg/optional_edge_table_clause.test
+++ b/test/sql/create_pg/optional_edge_table_clause.test
@@ -1,0 +1,13 @@
+# name: test/sql/sqlpgq/snb.test
+# group: [duckpgq]
+
+require duckpgq
+
+statement ok
+import database 'duckdb-pgq/data/SNB0.003';
+
+statement ok
+-CREATE PROPERTY GRAPH snb
+VERTEX TABLES (Message);
+
+statement ok


### PR DESCRIPTION
Fixes #83 

Following the SQL/PGQ specifications, the edge table clause should be optional. So a property graph can be defined with only vertex tables.

