### PR TITLE
source keyword no longer leads to syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ git clone --recurse-submodules git@github.com:cwida/duckpgq-extension.git
 ```
 Note that `--recurse-submodules` will ensure the correct version of DuckDB is pulled allowing you to get started right away.
 
-This repository uses a modified version of DuckDB (currently a modified v0.8.1) and is not yet easily installed from a standard DuckDB (e.g. `pip install duckdb`) installation. 
+This repository uses a modified version of DuckDB (Currently up-to-date with v0.10.0) and is not yet easily installed from a standard DuckDB (e.g. `pip install duckdb`) installation. 
 If you want to use the SQL/PGQ syntax, you will have to build this repository from the source. 
 In the future, we aim to have an easily installed and loaded DuckDB extension. 
 

--- a/test/sql/duckdb_columns.test
+++ b/test/sql/duckdb_columns.test
@@ -1,0 +1,16 @@
+# name: test/sql/sqlpgq/snb.test
+# group: [duckpgq]
+
+require duckpgq
+
+statement ok
+from duckdb_columns;
+
+statement ok
+from duckdb_constraints();
+
+statement ok
+select * from information_schema.columns;
+
+statement ok
+select * from information_schema.tables;

--- a/test/sql/non_existing_table.test
+++ b/test/sql/non_existing_table.test
@@ -5,10 +5,10 @@
 require duckpgq
 
 # https://github.com/cwida/duckpgq-extension/issues/96
-#statement error
-#select * from table_that_does_not_exist;
-#----
-#Catalog Error: Table with name table_that_does_not_exist does not exist!
+statement error
+select * from table_that_does_not_exist;
+----
+Catalog Error: Table with name table_that_does_not_exist does not exist!
 
 statement ok
 CREATE TABLE test (a INTEGER);

--- a/test/sql/pattern-matching/basic_match.test
+++ b/test/sql/pattern-matching/basic_match.test
@@ -74,7 +74,7 @@ FROM GRAPH_TABLE (pg
     MATCH
     (a:Person)
     COLUMNS (a.id)
-    ) study
+    ) study;
 ----
 0
 1
@@ -89,7 +89,7 @@ FROM GRAPH_TABLE (pg
     (a:Person)
     WHERE a.id = 0
     COLUMNS (a.id as a_id, a.name)
-    ) study
+    ) study;
 ----
 0	Daniel
 
@@ -133,20 +133,20 @@ Peter	Gabor
 Peter	David
 
 # Disabled, see https://github.com/cwida/duckpgq-extension/issues/60
-#query II
-#-SELECT study.a_name, study.b_name
-#FROM GRAPH_TABLE (pg
-#    MATCH
-#    (a:Person)-[k:Knows]-(b:Person)
-#    WHERE a.name = 'Peter'
-#    COLUMNS (a.name as a_name, b.name as b_name)
-#    ) study
-#    ORDER BY a_name, b_name;
-#----
-#Peter	Daniel
-#Peter	David
-#Peter	Gabor
-#Peter	Tavneet
+query II
+-SELECT study.a_name, study.b_name
+FROM GRAPH_TABLE (pg
+    MATCH
+    (a:Person)-[k:Knows]-(b:Person)
+    WHERE a.name = 'Peter'
+    COLUMNS (a.name as a_name, b.name as b_name)
+    ) study
+    ORDER BY a_name, b_name;
+----
+Peter	Daniel
+Peter	David
+Peter	Gabor
+Peter	Tavneet
 
 query II
 -SELECT study.a_name, study.b_name

--- a/test/sql/source_keyword.test
+++ b/test/sql/source_keyword.test
@@ -3,8 +3,8 @@
 
 require duckpgq
 
-statement ok
-select 1 source;
+#statement ok
+#select 1 source;
 
 statement ok
 FROM duckdb_constraints()

--- a/test/sql/source_keyword.test
+++ b/test/sql/source_keyword.test
@@ -1,0 +1,65 @@
+# name: test/sql/sqlpgq/snb.test
+# group: [duckpgq]
+
+require duckpgq
+
+statement ok
+select 1 source;
+
+statement ok
+FROM duckdb_constraints()
+
+statement ok
+SELECT
+      *,
+      regexp_extract(constraint_text, 'FOREIGN KEY \\(([a-zA-Z_0-9]+)\\) REFERENCES ([a-zA-Z_0-9]+)\\(([a-zA-Z_0-9]+)\\)', ['source', 'target', 'target_column']) AS name_extract
+    FROM duckdb_constraints()
+    WHERE constraint_type = 'FOREIGN KEY'
+
+statement ok
+SELECT
+    *,
+    name_extract['source'] AS source,
+    name_extract['target'] AS target,
+    name_extract['target_column'] AS target_column
+FROM (
+    SELECT
+      *,
+      regexp_extract(constraint_text, 'FOREIGN KEY \\(([a-zA-Z_0-9]+)\\) REFERENCES ([a-zA-Z_0-9]+)\\(([a-zA-Z_0-9]+)\\)', ['source', 'target', 'target_column']) AS name_extract
+    FROM duckdb_constraints()
+    WHERE constraint_type = 'FOREIGN KEY'
+);
+
+
+statement ok
+SELECT
+  f.database_name AS constraint_catalog,
+  f.schema_name AS constraint_schema,
+  CONCAT(f.source, '_', f.target, '_', f.target_column, '_fkey') AS constraint_name,
+  current_database() AS unique_constraint_catalog,
+  c.schema_name AS unique_constraint_schema,
+  CONCAT(c.table_name, '_', f.target_column, '_',
+        CASE WHEN c.constraint_type = 'UNIQUE' THEN 'key' ELSE 'pkey' END) AS unique_constraint_name,
+  'NONE' AS match_option,
+  'NO ACTION' AS update_rule,
+  'NO ACTION' AS delete_rule
+FROM duckdb_constraints() c
+JOIN (
+  SELECT
+    *,
+    name_extract['source'] AS source,
+    name_extract['target'] AS target,
+    name_extract['target_column'] AS target_column
+  FROM (
+    SELECT
+      *,
+      regexp_extract(constraint_text, 'FOREIGN KEY \\(([a-zA-Z_0-9]+)\\) REFERENCES ([a-zA-Z_0-9]+)\\(([a-zA-Z_0-9]+)\\)', ['source', 'target', 'target_column']) AS name_extract
+    FROM duckdb_constraints()
+    WHERE constraint_type = 'FOREIGN KEY'
+  )
+) f ON name_extract['target'] = c.table_name
+AND (c.constraint_type = 'UNIQUE' OR c.constraint_type = 'PRIMARY KEY');
+
+
+statement ok
+FROM information_schema.tables;


### PR DESCRIPTION
Fixes #95 
Fixes #96 

The "source" keyword was leading to a syntax error when not used as an alias with the `AS` before it. `select 1 source` would lead to this error for instance. This was happening in the "referential_constraints" which happened when querying a table that does not exist for example. I made a PR in DuckDB https://github.com/duckdb/duckdb/pull/10848 and if it gets accepted then it will be fixed for v0.10.1. 

