### PR TITLE
Add support for CREATE OR REPLACE PROPERTY GRAPH

### DIFF
--- a/duckpgq/src/duckpgq/functions/tablefunctions/create_property_graph.cpp
+++ b/duckpgq/src/duckpgq/functions/tablefunctions/create_property_graph.cpp
@@ -79,7 +79,8 @@ CreatePropertyGraphFunction::CreatePropertyGraphBind(
   auto pg_table =
       duckpgq_state->registered_property_graphs.find(info->property_graph_name);
 
-  if (pg_table != duckpgq_state->registered_property_graphs.end()) {
+  if (pg_table != duckpgq_state->registered_property_graphs.end() &&
+      info->on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
     throw Exception(ExceptionType::INVALID, "Property graph table with name " + info->property_graph_name + " already exists");
   }
 
@@ -163,13 +164,7 @@ void CreatePropertyGraphFunction::CreatePropertyGraphFunc(
     throw Exception(ExceptionType::INVALID,"Registered DuckPGQ state not found");
   }
   auto duckpgq_state = (DuckPGQState *)lookup->second.get();
-  auto pg_lookup = duckpgq_state->registered_property_graphs.find(
-      pg_info->property_graph_name);
-  if (pg_lookup == duckpgq_state->registered_property_graphs.end()) {
-    duckpgq_state->registered_property_graphs[pg_info->property_graph_name] =
-        pg_info->Copy();
-  } else {
-    throw Exception(ExceptionType::INVALID,"A property graph with name " + pg_info->property_graph_name + " already exists.");
-  }
+  duckpgq_state->registered_property_graphs[pg_info->property_graph_name] =
+    pg_info->Copy();
 }
 }; // namespace duckdb

--- a/test/sql/create_pg/create_or_replace_pg.test
+++ b/test/sql/create_pg/create_or_replace_pg.test
@@ -1,0 +1,42 @@
+# name: test/sql/sqlpgq/snb.test
+# group: [duckpgq]
+
+require duckpgq
+
+statement ok
+import database 'duckdb-pgq/data/SNB0.003';
+
+statement ok
+-CREATE PROPERTY GRAPH snb
+VERTEX TABLES (
+    Person LABEL Person
+    )
+EDGE TABLES (
+    Person_knows_person     SOURCE KEY (Person1Id) REFERENCES Person (id)
+                            DESTINATION KEY (Person2Id) REFERENCES Person (id)
+                            LABEL Knows
+    );
+
+# Fails because University is not registered
+statement error
+-FROM GRAPH_TABLE(snb MATCH (a:Person)-[w:workAt_Organisation]->(u:University)) limit 10;
+----
+Binder Error: The label university is not registered in property graph snb
+
+statement ok
+-CREATE OR REPLACE PROPERTY GRAPH snb
+VERTEX TABLES (
+    Person LABEL Person,
+    Organisation LABEL Organisation IN typemask(company, university)
+    )
+EDGE TABLES (
+    Person_knows_person     SOURCE KEY (Person1Id) REFERENCES Person (id)
+                            DESTINATION KEY (Person2Id) REFERENCES Person (id)
+                            LABEL Knows,
+    person_workAt_Organisation SOURCE KEY (PersonId) REFERENCES Person (id)
+                               DESTINATION KEY (OrganisationId) REFERENCES Organisation (id)
+                            LABEL workAt_Organisation
+    );
+
+statement ok
+-FROM GRAPH_TABLE(snb MATCH (a:Person)-[w:workAt_Organisation]->(u:University)) limit 10;


### PR DESCRIPTION
Fixes #19 

Now it's possible to `CREATE OR REPLACE PROPERTY GRAPH`, avoiding the need to first drop the property graph and then create it again in case it already exists. Using only `CREATE` with a name equal to an already existing property graph will still result in an error. 
