### PR TITLE
Extension now also works in python environment

### DIFF
--- a/test/python/duckpgq_test.py
+++ b/test/python/duckpgq_test.py
@@ -2,22 +2,28 @@ import duckdb
 import os
 import pytest
 
+
 # Get a fresh connection to DuckDB with the duckpgq extension binary loaded
 @pytest.fixture
 def duckdb_conn():
     extension_binary = os.getenv('DUCKPGQ_EXTENSION_BINARY_PATH')
-    if (extension_binary == ''):
+    if extension_binary == '':
         raise Exception('Please make sure the `DUCKPGQ_EXTENSION_BINARY_PATH` is set to run the python tests')
     conn = duckdb.connect('', config={'allow_unsigned_extensions': 'true'})
     conn.execute(f"load '{extension_binary}'")
     return conn
 
-def test_duckpgq(duckdb_conn):
-    duckdb_conn.execute("SELECT duckpgq('Sam') as value;");
-    res = duckdb_conn.fetchall()
-    assert(res[0][0] == "Duckpgq Sam 🐥");
 
-def test_duckpgq_openssl_version_test(duckdb_conn):
-    duckdb_conn.execute("SELECT duckpgq_openssl_version('Michael');");
+def test_duckpgq(duckdb_conn):
+    duckdb_conn.execute("SELECT duckpgq('Sam') as value;")
     res = duckdb_conn.fetchall()
-    assert(res[0][0][0:51] == "Duckpgq Michael, my linked OpenSSL version is OpenSSL");
+    assert (res[0][0] == "Duckpgq Sam 🐥");
+
+
+def test_property_graph(duckdb_conn):
+    duckdb_conn.execute("CREATE TABLE foo(i bigint)")
+    duckdb_conn.execute("INSERT INTO foo(i) VALUES (1)")
+    duckdb_conn.execute("-CREATE PROPERTY GRAPH t VERTEX TABLES (foo);")
+    duckdb_conn.execute("-FROM GRAPH_TABLE(t MATCH (f:foo))")
+    res = duckdb_conn.fetchall()
+    assert (res[0][0] == 1)


### PR DESCRIPTION
Fixes: https://github.com/cwida/duckpgq-extension/issues/100 🎉

You need to explicitly load the extension in Python, which I forgot about. This PR adds a simple test that works through `make test_python`

To debug pyTest > Edit configurations > Environment variables:
Name `DUCKPGQ_EXTENSION_BINARY_PATH`
Value `~/git/duckpgq/build/debug/extension/duckpgq/duckpgq.duckdb_extension`

Working directory should be `~/git/duckpgq/test/python`
Ready for debug