### PR TITLE
Improve performance on any directed edges

### DIFF
--- a/duckpgq/include/duckpgq/functions/tablefunctions/create_property_graph.hpp
+++ b/duckpgq/include/duckpgq/functions/tablefunctions/create_property_graph.hpp
@@ -22,14 +22,14 @@ public:
     function = CreatePropertyGraphFunc;
   }
 
-  struct CreatePropertyGraphBindData : TableFunctionData {
+  struct CreatePropertyGraphBindData : public TableFunctionData {
     explicit CreatePropertyGraphBindData(CreatePropertyGraphInfo *pg_info)
         : create_pg_info(pg_info) {}
 
     CreatePropertyGraphInfo *create_pg_info;
   };
 
-  struct CreatePropertyGraphGlobalData : GlobalTableFunctionState {
+  struct CreatePropertyGraphGlobalData : public GlobalTableFunctionState {
     CreatePropertyGraphGlobalData() = default;
   };
 

--- a/duckpgq/include/duckpgq/functions/tablefunctions/create_property_graph.hpp
+++ b/duckpgq/include/duckpgq/functions/tablefunctions/create_property_graph.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 #include "duckdb/function/table_function.hpp"
-#include "duckdb/parser/statement/create_statement.hpp"
 #include "duckdb/parser/parsed_data/create_property_graph_info.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 
@@ -23,14 +22,14 @@ public:
     function = CreatePropertyGraphFunc;
   }
 
-  struct CreatePropertyGraphBindData : public TableFunctionData {
+  struct CreatePropertyGraphBindData : TableFunctionData {
     explicit CreatePropertyGraphBindData(CreatePropertyGraphInfo *pg_info)
         : create_pg_info(pg_info) {}
 
     CreatePropertyGraphInfo *create_pg_info;
   };
 
-  struct CreatePropertyGraphGlobalData : public GlobalTableFunctionState {
+  struct CreatePropertyGraphGlobalData : GlobalTableFunctionState {
     CreatePropertyGraphGlobalData() = default;
   };
 
@@ -42,12 +41,12 @@ public:
   CheckPropertyGraphTableColumns(const shared_ptr<PropertyGraphTable> &pg_table,
                                  TableCatalogEntry &table);
 
-  static duckdb::unique_ptr<FunctionData>
+  static unique_ptr<FunctionData>
   CreatePropertyGraphBind(ClientContext &context, TableFunctionBindInput &input,
                           vector<LogicalType> &return_types,
                           vector<string> &names);
 
-  static duckdb::unique_ptr<GlobalTableFunctionState>
+  static unique_ptr<GlobalTableFunctionState>
   CreatePropertyGraphInit(ClientContext &context,
                           TableFunctionInitInput &input);
 

--- a/duckpgq/include/duckpgq/functions/tablefunctions/match.hpp
+++ b/duckpgq/include/duckpgq/functions/tablefunctions/match.hpp
@@ -68,8 +68,7 @@ public:
                           const string &prev_binding,
                           const string &next_binding,
                           vector<unique_ptr<ParsedExpression>> &conditions,
-                          unique_ptr<TableRef> &from_clause,
-              const vector<unique_ptr<ParsedExpression>> &column_list);
+                          unique_ptr<TableRef> &from_clause);
 
   static void EdgeTypeLeft(const shared_ptr<PropertyGraphTable> &edge_table,
                            const string &next_table_name,
@@ -130,8 +129,7 @@ public:
                vector<unique_ptr<ParsedExpression>> &conditions,
                unordered_map<string, string> &alias_map,
                int32_t &extra_alias_counter,
-               unique_ptr<TableRef> &from_clause,
-               vector<unique_ptr<ParsedExpression>> &column_list);
+               unique_ptr<TableRef> &from_clause);
 
   static void ProcessPathList(
       vector<unique_ptr<PathReference>> &path_pattern,

--- a/duckpgq/include/duckpgq/functions/tablefunctions/match.hpp
+++ b/duckpgq/include/duckpgq/functions/tablefunctions/match.hpp
@@ -68,7 +68,8 @@ public:
                           const string &prev_binding,
                           const string &next_binding,
                           vector<unique_ptr<ParsedExpression>> &conditions,
-                          unique_ptr<TableRef> &from_clause);
+                          unique_ptr<TableRef> &from_clause,
+              const vector<unique_ptr<ParsedExpression>> &column_list);
 
   static void EdgeTypeLeft(const shared_ptr<PropertyGraphTable> &edge_table,
                            const string &next_table_name,
@@ -121,8 +122,7 @@ public:
                              const SubPath *subpath);
 
   static void
-  AddEdgeJoins(const unique_ptr<SelectNode> &select_node,
-               const shared_ptr<PropertyGraphTable> &edge_table,
+  AddEdgeJoins(const shared_ptr<PropertyGraphTable> &edge_table,
                const shared_ptr<PropertyGraphTable> &previous_vertex_table,
                const shared_ptr<PropertyGraphTable> &next_vertex_table,
                PGQMatchType edge_type, const string &edge_binding,
@@ -130,7 +130,8 @@ public:
                vector<unique_ptr<ParsedExpression>> &conditions,
                unordered_map<string, string> &alias_map,
                int32_t &extra_alias_counter,
-               unique_ptr<TableRef> &from_clause);
+               unique_ptr<TableRef> &from_clause,
+               vector<unique_ptr<ParsedExpression>> &column_list);
 
   static void ProcessPathList(
       vector<unique_ptr<PathReference>> &path_pattern,

--- a/duckpgq/include/duckpgq/functions/tablefunctions/match.hpp
+++ b/duckpgq/include/duckpgq/functions/tablefunctions/match.hpp
@@ -67,7 +67,8 @@ public:
                           const string &edge_binding,
                           const string &prev_binding,
                           const string &next_binding,
-                          vector<unique_ptr<ParsedExpression>> &conditions);
+                          vector<unique_ptr<ParsedExpression>> &conditions,
+                          unique_ptr<TableRef> &from_clause);
 
   static void EdgeTypeLeft(const shared_ptr<PropertyGraphTable> &edge_table,
                            const string &next_table_name,
@@ -128,7 +129,8 @@ public:
                const string &prev_binding, const string &next_binding,
                vector<unique_ptr<ParsedExpression>> &conditions,
                unordered_map<string, string> &alias_map,
-               int32_t &extra_alias_counter);
+               int32_t &extra_alias_counter,
+               unique_ptr<TableRef> &from_clause);
 
   static void ProcessPathList(
       vector<unique_ptr<PathReference>> &path_pattern,

--- a/duckpgq/src/duckpgq/functions/tablefunctions/create_property_graph.cpp
+++ b/duckpgq/src/duckpgq/functions/tablefunctions/create_property_graph.cpp
@@ -67,7 +67,7 @@ CreatePropertyGraphFunction::CreatePropertyGraphBind(
     throw Exception(ExceptionType::INVALID,
                     "Registered DuckPGQ state not found");
   }
-  const auto duckpgq_state = (DuckPGQState *)lookup->second.get();
+  const auto duckpgq_state = dynamic_cast<DuckPGQState *>(lookup->second.get());
   const auto duckpgq_parse_data =
       dynamic_cast<DuckPGQParseData *>(duckpgq_state->parse_data.get());
 

--- a/duckpgq/src/duckpgq/functions/tablefunctions/create_property_graph.cpp
+++ b/duckpgq/src/duckpgq/functions/tablefunctions/create_property_graph.cpp
@@ -1,4 +1,5 @@
 #include "duckpgq/functions/tablefunctions/create_property_graph.hpp"
+#include "duckdb/parser/statement/create_statement.hpp"
 #include <duckpgq_extension.hpp>
 
 namespace duckdb {

--- a/duckpgq/src/duckpgq/functions/tablefunctions/match.cpp
+++ b/duckpgq/src/duckpgq/functions/tablefunctions/match.cpp
@@ -371,7 +371,7 @@ void PGQMatchFunction::EdgeTypeAny(
     const vector<unique_ptr<ParsedExpression>> &column_list) {
   vector<unique_ptr<ParsedExpression>> edge_columns;
   for (const auto& expr : column_list) {
-    const auto column_expr = expr->Cast<ColumnRefExpression>;
+    const auto column_expr = dynamic_cast<ColumnRefExpression*>(expr.get());
     if (column_expr == nullptr) {
       continue;
     }

--- a/duckpgq/src/duckpgq/functions/tablefunctions/match.cpp
+++ b/duckpgq/src/duckpgq/functions/tablefunctions/match.cpp
@@ -377,11 +377,11 @@ void PGQMatchFunction::EdgeTypeAny(
   src_dst_select_node->from_table = std::move(edge_left_ref);
   auto src_left_ref = make_uniq<ColumnRefExpression>(edge_table->source_fk[0], edge_table->table_name);
   auto dst_left_ref = make_uniq<ColumnRefExpression>(edge_table->destination_fk[0], edge_table->table_name);
-  auto star_left_expr = make_uniq<StarExpression>();
+  // auto star_left_expr = make_uniq<StarExpression>();
   auto src_dst_children = vector<unique_ptr<ParsedExpression>>();
   src_dst_children.push_back(std::move(src_left_ref));
   src_dst_children.push_back(std::move(dst_left_ref));
-  src_dst_children.push_back(std::move(star_left_expr));
+  // src_dst_children.push_back(std::move(star_left_expr));
   src_dst_select_node->select_list = std::move(src_dst_children);
   // END SELECT src, dst, * from edge_table
 
@@ -394,11 +394,11 @@ void PGQMatchFunction::EdgeTypeAny(
   auto dst_right_ref = make_uniq<ColumnRefExpression>(
       edge_table->destination_fk[0], edge_table->table_name);
   auto src_right_ref = make_uniq<ColumnRefExpression>(edge_table->source_fk[0], edge_table->table_name);
-  auto star_right_expr = make_uniq<StarExpression>();
+  // auto star_right_expr = make_uniq<StarExpression>();
   auto dst_src_children = vector<unique_ptr<ParsedExpression>>();
   dst_src_children.push_back(std::move(dst_right_ref));
   dst_src_children.push_back(std::move(src_right_ref));
-  dst_src_children.push_back(std::move(star_right_expr));
+  // dst_src_children.push_back(std::move(star_right_expr));
   dst_src_select_node->select_list = std::move(dst_src_children);
   // END SELECT dst, src, * from edge_table
 
@@ -1047,7 +1047,7 @@ PGQMatchFunction::MatchBindReplace(ClientContext &context,
   subquery->node = std::move(select_node);
 
   auto result = make_uniq<SubqueryRef>(std::move(subquery), ref->alias);
-
+  result->Print();
   return std::move(result);
 }
 } // namespace duckdb

--- a/duckpgq/src/duckpgq/functions/tablefunctions/match.cpp
+++ b/duckpgq/src/duckpgq/functions/tablefunctions/match.cpp
@@ -422,7 +422,7 @@ void PGQMatchFunction::EdgeTypeAny(
   union_node->right = std::move(dst_src_select_node);
   auto union_select = make_uniq<SelectStatement>();
   union_select->node = std::move(union_node);
-  // (SELECT src, dst, * from edge_table UNION ALL SELECT dst, src, * from edge_table UNION ALL)
+  // (SELECT src, dst, * from edge_table UNION ALL SELECT dst, src, * from edge_table)
   auto union_subquery = make_uniq<SubqueryRef>(std::move(union_select));
   union_subquery->alias = edge_binding;
   if (from_clause) {

--- a/duckpgq/src/duckpgq/functions/tablefunctions/match.cpp
+++ b/duckpgq/src/duckpgq/functions/tablefunctions/match.cpp
@@ -388,19 +388,8 @@ void PGQMatchFunction::EdgeTypeAny(
   auto src_dst_children = vector<unique_ptr<ParsedExpression>>();
   src_dst_children.push_back(make_uniq<ColumnRefExpression>(edge_table->source_fk[0], edge_table->table_name));
   src_dst_children.push_back(make_uniq<ColumnRefExpression>(edge_table->destination_fk[0], edge_table->table_name));
-  for (const auto& expr : edge_columns) {
-    src_dst_children.push_back(expr->Copy());
-  }
+  src_dst_children.push_back(make_uniq<StarExpression>());
 
-  // unordered_set<string> added_columns;
-  // added_columns.insert(edge_table->source_fk[0]);
-  // added_columns.insert(edge_table->destination_fk[0]);
-  // for (const auto& col : edge_table->column_names) {
-  //   if (added_columns.find(col) == added_columns.end()) {
-  //     src_dst_children.push_back(make_uniq<ColumnRefExpression>(col, edge_table->table_name));
-  //     added_columns.insert(col);
-  //   }
-  // }
   src_dst_select_node->select_list = std::move(src_dst_children);
   // END SELECT src, dst, * from edge_table
 
@@ -416,18 +405,7 @@ void PGQMatchFunction::EdgeTypeAny(
       edge_table->destination_fk[0], edge_table->table_name));
   dst_src_children.push_back(make_uniq<ColumnRefExpression>(edge_table->source_fk[0],
                                                       edge_table->table_name));
-  for (const auto& expr : edge_columns) {
-    dst_src_children.push_back(expr->Copy());
-  }
-  // added_columns.clear();
-  // added_columns.insert(edge_table->destination_fk[0]);
-  // added_columns.insert(edge_table->source_fk[0]);
-  // for (const auto& col : edge_table->column_names) {
-  //   if (added_columns.find(col) == added_columns.end()) {
-  //     dst_src_children.push_back(make_uniq<ColumnRefExpression>(col, edge_table->table_name));
-  //     added_columns.insert(col);
-  //   }
-  // }
+  dst_src_children.push_back(make_uniq<StarExpression>());
 
   dst_src_select_node->select_list = std::move(dst_src_children);
   // END SELECT dst, src, * from edge_table

--- a/duckpgq/src/duckpgq/functions/tablefunctions/match.cpp
+++ b/duckpgq/src/duckpgq/functions/tablefunctions/match.cpp
@@ -1074,7 +1074,6 @@ PGQMatchFunction::MatchBindReplace(ClientContext &context,
   subquery->node = std::move(select_node);
 
   auto result = make_uniq<SubqueryRef>(std::move(subquery), ref->alias);
-  result->Print();
   return std::move(result);
 }
 } // namespace duckdb

--- a/duckpgq/src/duckpgq_extension.cpp
+++ b/duckpgq/src/duckpgq_extension.cpp
@@ -102,7 +102,7 @@ BoundStatement duckpgq_bind(ClientContext &context, Binder &binder,
   }
 
   auto duckpgq_state = (DuckPGQState *)lookup->second.get();
-  auto duckpgq_binder = Binder::CreateBinder(context);
+  auto duckpgq_binder = Binder::CreateBinder(context, &binder);
   auto duckpgq_parse_data =
       dynamic_cast<DuckPGQParseData *>(duckpgq_state->parse_data.get());
   if (duckpgq_parse_data) {

--- a/duckpgq/src/duckpgq_extension.cpp
+++ b/duckpgq/src/duckpgq_extension.cpp
@@ -16,6 +16,7 @@
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/statement/copy_statement.hpp"
+#include "duckdb/parser/statement/create_statement.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/parser/tableref/joinref.hpp"
 

--- a/test/sql/create_pg/optional_edge_table_clause.test
+++ b/test/sql/create_pg/optional_edge_table_clause.test
@@ -3,12 +3,19 @@
 
 require duckpgq
 
+statement error
+-CREATE PROPERTY GRAPH snb
+VERTEX TABLES (tabledoesnotexist);
+----
+
+
 statement ok
 import database 'duckdb-pgq/data/SNB0.003';
 
 statement ok
 -CREATE PROPERTY GRAPH snb
 VERTEX TABLES (Message, person);
+
 
 statement ok
 -FROM GRAPH_TABLE (snb

--- a/test/sql/create_pg/optional_edge_table_clause.test
+++ b/test/sql/create_pg/optional_edge_table_clause.test
@@ -1,13 +1,7 @@
-# name: test/sql/sqlpgq/snb.test
+# name: test/sql/create_pg/optional_edge_table_clause.test
 # group: [duckpgq]
 
 require duckpgq
-
-statement error
--CREATE PROPERTY GRAPH snb
-VERTEX TABLES (tabledoesnotexist);
-----
-
 
 statement ok
 import database 'duckdb-pgq/data/SNB0.003';

--- a/test/sql/pattern-matching/basic_match.test
+++ b/test/sql/pattern-matching/basic_match.test
@@ -132,7 +132,6 @@ Peter	Tavneet
 Peter	Gabor
 Peter	David
 
-# Disabled, see https://github.com/cwida/duckpgq-extension/issues/60
 query II
 -SELECT study.a_name, study.b_name
 FROM GRAPH_TABLE (pg
@@ -143,6 +142,7 @@ FROM GRAPH_TABLE (pg
     ) study
     ORDER BY a_name, b_name;
 ----
+Peter	Daniel
 Peter	Daniel
 Peter	David
 Peter	Gabor

--- a/test/sql/pattern-matching/undirected_edges.test
+++ b/test/sql/pattern-matching/undirected_edges.test
@@ -21,9 +21,9 @@ EDGE TABLES (
     );
 
 query II
-SELECT a."name" AS person, b."name" AS friend
-    FROM ((SELECT know.src, know.dst, know.createDate FROM know) UNION ALL (SELECT know.dst, know.src, know.createDate FROM know)) AS k , Student AS b , Student AS a
-    WHERE ((a.id = k.src) AND (b.id = k.dst) AND (a."name" = 'Daniel'));
+SELECT a.name AS person, b.name AS friend
+    FROM ((SELECT know.src, know.dst FROM know) UNION ALL (SELECT know.dst, know.src FROM know)) AS k , Student AS b , Student AS a
+    WHERE ((a.id = k.src) AND (b.id = k.dst) AND (a.name = 'Daniel'));
 ----
 Daniel	Tavneet
 Daniel	Gabor
@@ -32,16 +32,34 @@ Daniel	David
 Daniel	Peter
 
 # Daniel has 3 outgoing edges and 2 incoming edges, so there should be 5 tuples
+#query III
+#-FROM GRAPH_TABLE (pg
+#    MATCH
+#    (a:Student)-[k:know]-(b:Student)
+#    WHERE a.name = 'Daniel'
+#    COLUMNS (a.name as person, b.name as friend, k.createDate as date)
+#    )
+#ORDER BY person, friend, date;
+#----
+#Daniel	David	18
+#Daniel	Gabor	11
+#Daniel	Peter	12
+#Daniel	Peter	13
+#Daniel	Tavneet	10
+
+# Daniel has 3 outgoing edges and 2 incoming edges, so there should be 5 tuples
 query II
--FROM GRAPH_TABLE (pg
+-SELECT person, friend, date
+FROM GRAPH_TABLE (pg
     MATCH
     (a:Student)-[k:know]-(b:Student)
     WHERE a.name = 'Daniel'
-    COLUMNS (a.name as person, b.name as friend)
-    );
+    COLUMNS (a.name as person, b.name as friend, k.createDate as date)
+    )
+ORDER BY person, friend;
 ----
-Daniel	Tavneet
+Daniel	David
 Daniel	Gabor
 Daniel	Peter
-Daniel	David
 Daniel	Peter
+Daniel	Tavneet

--- a/test/sql/pattern-matching/undirected_edges.test
+++ b/test/sql/pattern-matching/undirected_edges.test
@@ -32,20 +32,20 @@ Daniel	David
 Daniel	Peter
 
 # Daniel has 3 outgoing edges and 2 incoming edges, so there should be 5 tuples
-#query III
-#-FROM GRAPH_TABLE (pg
-#    MATCH
-#    (a:Student)-[k:know]-(b:Student)
-#    WHERE a.name = 'Daniel'
-#    COLUMNS (a.name as person, b.name as friend, k.createDate as date)
-#    )
-#ORDER BY person, friend, date;
-#----
-#Daniel	David	18
-#Daniel	Gabor	11
-#Daniel	Peter	12
-#Daniel	Peter	13
-#Daniel	Tavneet	10
+query III
+-FROM GRAPH_TABLE (pg
+    MATCH
+    (a:Student)-[k:know]-(b:Student)
+    WHERE a.name = 'Daniel'
+    COLUMNS (a.name as person, b.name as friend, k.createDate as date)
+    )
+ORDER BY person, friend, date;
+----
+Daniel	David	18
+Daniel	Gabor	11
+Daniel	Peter	12
+Daniel	Peter	13
+Daniel	Tavneet	10
 
 # Daniel has 3 outgoing edges and 2 incoming edges, so there should be 5 tuples
 query II

--- a/test/sql/pattern-matching/undirected_edges.test
+++ b/test/sql/pattern-matching/undirected_edges.test
@@ -20,6 +20,17 @@ EDGE TABLES (
             DESTINATION KEY ( dst ) REFERENCES Student ( id )
     );
 
+query II
+SELECT a."name" AS person, b."name" AS friend
+    FROM ((SELECT know.src, know.dst, know.createDate FROM know) UNION ALL (SELECT know.dst, know.src, know.createDate FROM know)) AS k , Student AS b , Student AS a
+    WHERE ((a.id = k.src) AND (b.id = k.dst) AND (a."name" = 'Daniel'));
+----
+Daniel	Tavneet
+Daniel	Gabor
+Daniel	Peter
+Daniel	David
+Daniel	Peter
+
 # Daniel has 3 outgoing edges and 2 incoming edges, so there should be 5 tuples
 query II
 -FROM GRAPH_TABLE (pg

--- a/test/sql/pattern-matching/undirected_edges.test
+++ b/test/sql/pattern-matching/undirected_edges.test
@@ -21,10 +21,9 @@ EDGE TABLES (
     );
 
 statement ok
--SELECT study.name, study.school
-FROM GRAPH_TABLE (pg
+-FROM GRAPH_TABLE (pg
     MATCH
-    (a:Person)-[k:knows]-(b:Person)
+    (a:Student)-[k:know]-(b:Student)
     WHERE a.name = 'Daniel'
     COLUMNS (a.name as person, b.name as friend)
-    ) study;
+    );

--- a/test/sql/pattern-matching/undirected_edges.test
+++ b/test/sql/pattern-matching/undirected_edges.test
@@ -20,6 +20,7 @@ EDGE TABLES (
             DESTINATION KEY ( dst ) REFERENCES Student ( id )
     );
 
+# Daniel has 3 outgoing edges and 2 incoming edges, so there should be 5 tuples
 query II
 -FROM GRAPH_TABLE (pg
     MATCH
@@ -29,6 +30,7 @@ query II
     );
 ----
 Daniel	Tavneet
+Daniel	Gabor
 Daniel	Peter
 Daniel	David
-Daniel	Gabor
+Daniel	Peter

--- a/test/sql/pattern-matching/undirected_edges.test
+++ b/test/sql/pattern-matching/undirected_edges.test
@@ -10,7 +10,7 @@ statement ok
 CREATE TABLE Student(id BIGINT, name VARCHAR);INSERT INTO Student VALUES (0, 'Daniel'), (1, 'Tavneet'), (2, 'Gabor'), (3, 'Peter'), (4, 'David');
 
 statement ok
-CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (3,0, 13), (1,2, 14), (1,3, 15), (2,3, 16), (4,3, 17);
+CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (3,0, 13), (1,2, 14), (1,3, 15), (2,3, 16), (4,3, 17), (4, 0, 18);
 
 statement ok
 -CREATE PROPERTY GRAPH pg
@@ -20,10 +20,15 @@ EDGE TABLES (
             DESTINATION KEY ( dst ) REFERENCES Student ( id )
     );
 
-statement ok
+query II
 -FROM GRAPH_TABLE (pg
     MATCH
     (a:Student)-[k:know]-(b:Student)
     WHERE a.name = 'Daniel'
     COLUMNS (a.name as person, b.name as friend)
     );
+----
+Daniel	Tavneet
+Daniel	Peter
+Daniel	David
+Daniel	Gabor

--- a/test/sql/pattern-matching/undirected_edges.test
+++ b/test/sql/pattern-matching/undirected_edges.test
@@ -1,0 +1,30 @@
+# name: test/sql/sqlpgq/undirected_edges.test
+# group: [duckpgq]
+
+statement ok
+pragma enable_verification
+
+require duckpgq
+
+statement ok
+CREATE TABLE Student(id BIGINT, name VARCHAR);INSERT INTO Student VALUES (0, 'Daniel'), (1, 'Tavneet'), (2, 'Gabor'), (3, 'Peter'), (4, 'David');
+
+statement ok
+CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (3,0, 13), (1,2, 14), (1,3, 15), (2,3, 16), (4,3, 17);
+
+statement ok
+-CREATE PROPERTY GRAPH pg
+VERTEX TABLES (Student)
+EDGE TABLES (
+    know    SOURCE KEY ( src ) REFERENCES Student ( id )
+            DESTINATION KEY ( dst ) REFERENCES Student ( id )
+    );
+
+statement ok
+-SELECT study.name, study.school
+FROM GRAPH_TABLE (pg
+    MATCH
+    (a:Person)-[k:knows]-(b:Person)
+    WHERE a.name = 'Daniel'
+    COLUMNS (a.name as person, b.name as friend)
+    ) study;

--- a/test/sql/pattern-matching/undirected_edges.test
+++ b/test/sql/pattern-matching/undirected_edges.test
@@ -32,6 +32,23 @@ Daniel	David
 Daniel	Peter
 
 # Daniel has 3 outgoing edges and 2 incoming edges, so there should be 5 tuples
+query II
+-SELECT person, friend
+FROM GRAPH_TABLE (pg
+    MATCH
+    (a:Student)-[k:know]-(b:Student)
+    WHERE a.name = 'Daniel'
+    COLUMNS (a.name as person, b.name as friend)
+    )
+ORDER BY person, friend;
+----
+Daniel	David
+Daniel	Gabor
+Daniel	Peter
+Daniel	Peter
+Daniel	Tavneet
+
+# Daniel has 3 outgoing edges and 2 incoming edges, so there should be 5 tuples
 query III
 -FROM GRAPH_TABLE (pg
     MATCH
@@ -47,19 +64,3 @@ Daniel	Peter	12
 Daniel	Peter	13
 Daniel	Tavneet	10
 
-# Daniel has 3 outgoing edges and 2 incoming edges, so there should be 5 tuples
-query II
--SELECT person, friend, date
-FROM GRAPH_TABLE (pg
-    MATCH
-    (a:Student)-[k:know]-(b:Student)
-    WHERE a.name = 'Daniel'
-    COLUMNS (a.name as person, b.name as friend, k.createDate as date)
-    )
-ORDER BY person, friend;
-----
-Daniel	David
-Daniel	Gabor
-Daniel	Peter
-Daniel	Peter
-Daniel	Tavneet


### PR DESCRIPTION
Fixes #107
Fixes #109
Fixes #60 

A bottleneck was the edge patterns containing the `ANY` edge (`-[]-`), see IS3. Previously this resulted in a slow blockwise nested loop join. We transform it into a union on the edge table (`src, dst, * from edge_table UNION ALL dst, src, * from edge_table`), resulting in two hash joins. 

