### PR TITLE
Error handling for multiple graph tables in single query

### DIFF
--- a/src/duckpgq_extension.cpp
+++ b/src/duckpgq_extension.cpp
@@ -120,6 +120,10 @@ void duckpgq_find_match_function(TableRef *table_ref,
     auto function =
         dynamic_cast<FunctionExpression *>(table_function_ref->function.get());
     if (function->function_name == "duckpgq_match") {
+      if (duckpgq_state.transform_expression != nullptr) {
+        throw Exception(ExceptionType::INVALID,
+                        "Multiple graph tables in a single query are not supported yet");
+      }
       duckpgq_state.transform_expression =
           std::move(std::move(function->children[0]));
       function->children.pop_back();

--- a/src/functions/tablefunctions/match.cpp
+++ b/src/functions/tablefunctions/match.cpp
@@ -26,6 +26,7 @@
 #include "duckdb/parser/subpath_element.hpp"
 #include <cmath>
 #include <duckdb/common/enums/set_operation_type.hpp>
+#include <fmt/format.h>
 
 namespace duckdb {
 shared_ptr<PropertyGraphTable>

--- a/src/include/duckpgq_extension.hpp
+++ b/src/include/duckpgq_extension.hpp
@@ -79,6 +79,7 @@ public:
 
   void QueryEnd() override {
     parse_data.reset();
+    transform_expression = nullptr;
     for (const auto &csr_id : csr_to_delete) {
       csr_list.erase(csr_id);
     }

--- a/test/sql/multiple_graph_table_error.test
+++ b/test/sql/multiple_graph_table_error.test
@@ -1,0 +1,33 @@
+# name: test/sql/sqlpgq/multiple_graph_table_error.test
+# group: [duckpgq]
+
+require duckpgq
+
+statement ok
+CREATE TABLE cities (
+name VARCHAR,
+lat DECIMAL,
+lon DECIMAL
+);
+
+statement ok
+CREATE TABLE cities_are_adjacent (
+city1name VARCHAR,
+city2name VARCHAR
+);
+
+statement ok
+-CREATE PROPERTY GRAPH citymap
+VERTEX TABLES (
+cities PROPERTIES (name,lat,lon) LABEL city
+)
+EDGE TABLES (
+cities_are_adjacent SOURCE KEY ( city1name ) REFERENCES cities ( name )
+DESTINATION KEY ( city2name ) REFERENCES cities ( name )
+LABEL adjacent
+);
+
+statement error
+-select * from GRAPH_TABLE (citymap MATCH (s:city)-[r:adjacent]->(t:city)) g1, GRAPH_TABLE (citymap MATCH (s:city)-[r:adjacent]->(t:city)) g2;
+----
+Invalid Error: Multiple graph tables in a single query are not supported yet

--- a/test/sql/multiple_graph_table_error.test
+++ b/test/sql/multiple_graph_table_error.test
@@ -31,3 +31,15 @@ statement error
 -select * from GRAPH_TABLE (citymap MATCH (s:city)-[r:adjacent]->(t:city)) g1, GRAPH_TABLE (citymap MATCH (s:city)-[r:adjacent]->(t:city)) g2;
 ----
 Invalid Error: Multiple graph tables in a single query are not supported yet
+
+statement ok
+-FROM GRAPH_TABLE (citymap MATCH (s:city)-[r:adjacent]->(t:city)) g1;
+
+statement ok
+-FROM GRAPH_TABLE (citymap MATCH (s:city)-[r:adjacent]->(t:city)) g1;
+
+statement error
+-select * from GRAPH_TABLE (citymap MATCH (s:city)-[r:adjacent]->(t:city)) g1, GRAPH_TABLE (citymap MATCH (s:city)-[r:adjacent]->(t:city)) g2;
+----
+Invalid Error: Multiple graph tables in a single query are not supported yet
+


### PR DESCRIPTION
Part of #88
Only ensures a proper error is thrown instead of an internal error that crashes the program