### PR TITLE
Local clustering coefficient

### DIFF
--- a/scripts/set_tag.sh
+++ b/scripts/set_tag.sh
@@ -4,12 +4,12 @@ set -eu
 set -o pipefail
 
 cd "$( cd "$( dirname "${BASH_SOURCE[0]:-${(%):-%x}}" )" >/dev/null 2>&1 && pwd )"
-
 cd ..
-git tag -d $1 || true
-git push --delete origin $1 || true
-git tag -a $1 -m "DuckPGQ '$1'"
-git push --tags
+
+#git tag -d $1 || true
+#git push --delete origin $1 || true
+#git tag -a $1 -m "DuckPGQ '$1'"
+#git push --tags
 
 cd duckdb-pgq
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -9,6 +9,23 @@
 
 namespace duckdb {
 
+DuckPGQBitmap::DuckPGQBitmap(size_t size) : size(size) {
+  bitmap.resize((size + 63) / 64, 0);
+}
+
+void DuckPGQBitmap::set(size_t index) {
+  bitmap[index / 64] |= (1ULL << (index % 64));
+}
+
+bool DuckPGQBitmap::test(size_t index) const {
+  return (bitmap[index / 64] & (1ULL << (index % 64))) != 0;
+}
+
+void DuckPGQBitmap::reset() {
+  std::fill(bitmap.begin(), bitmap.end(), 0);
+}
+
+
 CSRFunctionData::CSRFunctionData(ClientContext &context, int32_t id,
                                  LogicalType weight_type)
     : context(context), id(id), weight_type(std::move(weight_type)) {}

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -79,6 +79,20 @@ bool IterativeLengthFunctionData::Equals(const FunctionData &other_p) const {
   return other.csr_id == csr_id;
 }
 
+unique_ptr<FunctionData>
+LocalClusteringCoefficientFunctionData::LocalClusteringCoefficientBind(
+    ClientContext &context, ScalarFunction &bound_function,
+    vector<unique_ptr<Expression>> &arguments) {
+  if (!arguments[0]->IsFoldable()) {
+    throw InvalidInputException("Id must be constant.");
+  }
+
+  int32_t csr_id = ExpressionExecutor::EvaluateScalar(context, *arguments[0])
+                       .GetValue<int32_t>();
+
+  return make_uniq<IterativeLengthFunctionData>(context, csr_id);
+}
+
 unique_ptr<FunctionData> IterativeLengthFunctionData::IterativeLengthBind(
     ClientContext &context, ScalarFunction &bound_function,
     vector<unique_ptr<Expression>> &arguments) {

--- a/src/duckpgq_extension.cpp
+++ b/src/duckpgq_extension.cpp
@@ -25,10 +25,12 @@
 
 #include "duckdb/parser/statement/extension_statement.hpp"
 
-#include "duckpgq/functions/tablefunctions/drop_property_graph.hpp"
 #include "duckpgq/functions/tablefunctions/create_property_graph.hpp"
 #include "duckpgq/functions/tablefunctions/describe_property_graph.hpp"
+#include "duckpgq/functions/tablefunctions/drop_property_graph.hpp"
 #include "duckpgq/functions/tablefunctions/match.hpp"
+
+#include <duckpgq/functions/tablefunctions/local_clustering_coefficient.hpp>
 
 namespace duckdb {
 
@@ -64,6 +66,11 @@ static void LoadInternal(DatabaseInstance &instance) {
   DropPropertyGraphFunction drop_pg_function;
   CreateTableFunctionInfo drop_pg_info(drop_pg_function);
   catalog.CreateTableFunction(*con.context, drop_pg_info);
+
+  LocalClusteringCoefficientFunction local_clustering_coefficient_function;
+  CreateTableFunctionInfo local_clustering_coefficient_info(
+      local_clustering_coefficient_function);
+  catalog.CreateTableFunction(*con.context, local_clustering_coefficient_info);
 
   for (auto &fun : DuckPGQFunctions::GetFunctions()) {
     catalog.CreateFunction(*con.context, fun);

--- a/src/functions/scalar/CMakeLists.txt
+++ b/src/functions/scalar/CMakeLists.txt
@@ -10,5 +10,6 @@ set(EXTENSION_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/reachability.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/shortest_path.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/csr_creation.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/local_clustering_coefficient.cpp
         PARENT_SCOPE
     )

--- a/src/functions/scalar/local_clustering_coefficient.cpp
+++ b/src/functions/scalar/local_clustering_coefficient.cpp
@@ -1,0 +1,67 @@
+#include <duckpgq_extension.hpp>
+#include "duckdb/main/client_data.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckpgq/common.hpp"
+#include "duckpgq/duckpgq_functions.hpp"
+
+
+namespace duckdb {
+static void LocalClusteringCoefficientFunction(DataChunk &args, ExpressionState &state,
+                                    Vector &result) {
+  auto &func_expr = (BoundFunctionExpression &)state.expr;
+  auto &info = (IterativeLengthFunctionData &)*func_expr.bind_info;
+  auto duckpgq_state_entry = info.context.registered_state.find("duckpgq");
+  if (duckpgq_state_entry == info.context.registered_state.end()) {
+    //! Wondering how you can get here if the extension wasn't loaded, but
+    //! leaving this check in anyways
+    throw MissingExtensionException(
+        "The DuckPGQ extension has not been loaded");
+  }
+  auto duckpgq_state =
+      reinterpret_cast<DuckPGQState *>(duckpgq_state_entry->second.get());
+
+  D_ASSERT(duckpgq_state->csr_list[info.csr_id]);
+
+  if ((uint64_t)info.csr_id + 1 > duckpgq_state->csr_list.size()) {
+    throw ConstraintException("Invalid ID");
+  }
+  auto csr_entry = duckpgq_state->csr_list.find((uint64_t)info.csr_id);
+  if (csr_entry == duckpgq_state->csr_list.end()) {
+    throw ConstraintException(
+        "Need to initialize CSR before doing shortest path");
+  }
+
+  if (!(csr_entry->second->initialized_v && csr_entry->second->initialized_e)) {
+    throw ConstraintException(
+        "Need to initialize CSR before doing shortest path");
+  }
+  int64_t *v = (int64_t *)duckpgq_state->csr_list[info.csr_id]->v;
+  vector<int64_t> &e = duckpgq_state->csr_list[info.csr_id]->e;
+
+  // get src and dst vectors for searches
+  auto &src = args.data[2];
+  UnifiedVectorFormat vdata_src;
+  src.ToUnifiedFormat(args.size(), vdata_src);
+  auto src_data = (int64_t *)vdata_src.data;
+
+  ValidityMask &result_validity = FlatVector::Validity(result);
+
+  // create result vector
+  result.SetVectorType(VectorType::FLAT_VECTOR);
+  auto result_data = FlatVector::GetData<int64_t>(result);
+
+
+  duckpgq_state->csr_to_delete.insert(info.csr_id);
+}
+
+CreateScalarFunctionInfo DuckPGQFunctions::GetLocalClusteringCoefficientFunction() {
+  auto fun = ScalarFunction("local_clustering_coefficient",
+                            {LogicalType::INTEGER, LogicalType::BIGINT},
+                            LogicalType::BIGINT, LocalClusteringCoefficientFunction,
+                            LocalClusteringCoefficientFunctionData::LocalClusteringCoefficientBind);
+  return CreateScalarFunctionInfo(fun);
+}
+
+}
+

--- a/src/functions/scalar/local_clustering_coefficient.cpp
+++ b/src/functions/scalar/local_clustering_coefficient.cpp
@@ -40,7 +40,7 @@ static void LocalClusteringCoefficientFunction(DataChunk &args, ExpressionState 
   vector<int64_t> &e = duckpgq_state->csr_list[info.csr_id]->e;
 
   // get src and dst vectors for searches
-  auto &src = args.data[2];
+  auto &src = args.data[1];
   UnifiedVectorFormat vdata_src;
   src.ToUnifiedFormat(args.size(), vdata_src);
   auto src_data = (int64_t *)vdata_src.data;

--- a/src/functions/scalar/local_clustering_coefficient.cpp
+++ b/src/functions/scalar/local_clustering_coefficient.cpp
@@ -36,11 +36,12 @@ static void LocalClusteringCoefficientFunction(DataChunk &args, ExpressionState 
 
   if (!(csr_entry->second->initialized_v && csr_entry->second->initialized_e)) {
     throw ConstraintException(
-        "Need to initialize CSR before doing shortest path");
+        "Need to initialize CSR before doing local clustering coefficient.");
   }
   int64_t *v = (int64_t *)duckpgq_state->csr_list[info.csr_id]->v;
   vector<int64_t> &e = duckpgq_state->csr_list[info.csr_id]->e;
   size_t v_size = duckpgq_state->csr_list[info.csr_id]->vsize;
+  std::cout << duckpgq_state->csr_list[info.csr_id]->ToString();
   // get src and dst vectors for searches
   auto &src = args.data[1];
   UnifiedVectorFormat vdata_src;

--- a/src/functions/scalar/local_clustering_coefficient.cpp
+++ b/src/functions/scalar/local_clustering_coefficient.cpp
@@ -41,7 +41,6 @@ static void LocalClusteringCoefficientFunction(DataChunk &args, ExpressionState 
   int64_t *v = (int64_t *)duckpgq_state->csr_list[info.csr_id]->v;
   vector<int64_t> &e = duckpgq_state->csr_list[info.csr_id]->e;
   size_t v_size = duckpgq_state->csr_list[info.csr_id]->vsize;
-  std::cout << duckpgq_state->csr_list[info.csr_id]->ToString();
   // get src and dst vectors for searches
   auto &src = args.data[1];
   UnifiedVectorFormat vdata_src;

--- a/src/functions/scalar/local_clustering_coefficient.cpp
+++ b/src/functions/scalar/local_clustering_coefficient.cpp
@@ -38,7 +38,7 @@ static void LocalClusteringCoefficientFunction(DataChunk &args, ExpressionState 
   }
   int64_t *v = (int64_t *)duckpgq_state->csr_list[info.csr_id]->v;
   vector<int64_t> &e = duckpgq_state->csr_list[info.csr_id]->e;
-
+  std::cout << duckpgq_state->csr_list[info.csr_id]->ToString();
   // get src and dst vectors for searches
   auto &src = args.data[1];
   UnifiedVectorFormat vdata_src;
@@ -48,11 +48,17 @@ static void LocalClusteringCoefficientFunction(DataChunk &args, ExpressionState 
   ValidityMask &result_validity = FlatVector::Validity(result);
   // create result vector
   result.SetVectorType(VectorType::FLAT_VECTOR);
-  auto result_data = FlatVector::GetData<int64_t>(result);
+  auto result_data = FlatVector::GetData<float_t>(result);
 
   for (int32_t n = 0; n < args.size(); n++) {
-    int64_t src_node = src_data[n];
-    int64_t count = 0;
+    auto src_sel = vdata_src.sel->get_index(n);
+    int64_t src_node = src_data[src_sel];
+    int32_t number_of_edges = v[src_node + 1] - v[src_node];
+    if (number_of_edges < 2) {
+      result_data[n] = static_cast<float_t>(0.0);
+      continue;
+    }
+    int32_t count = 0;
     for (auto offset = v[src_node]; offset < v[src_node + 1]; offset++) {
       auto neighbour = e[offset];
       for (auto offset2 = v[neighbour]; offset2 < v[neighbour + 1]; offset2++) {
@@ -65,13 +71,9 @@ static void LocalClusteringCoefficientFunction(DataChunk &args, ExpressionState 
         }
       }
     }
-    int32_t number_of_edges = v[src_node + 1] - v[src_node];
-    if (number_of_edges > 1) {
-      count = count / (number_of_edges * (number_of_edges - 1));
-    } else {
-      count = 0;
-    }
-    result_data[n] = count;
+    float_t local_result =  static_cast<float_t>(count) / (number_of_edges * (number_of_edges - 1));
+    std::cout << src_node << " " << count << " " << number_of_edges << " " << local_result << std::endl;
+    result_data[n] = local_result;
   }
 
   duckpgq_state->csr_to_delete.insert(info.csr_id);
@@ -80,7 +82,7 @@ static void LocalClusteringCoefficientFunction(DataChunk &args, ExpressionState 
 CreateScalarFunctionInfo DuckPGQFunctions::GetLocalClusteringCoefficientFunction() {
   auto fun = ScalarFunction("local_clustering_coefficient",
                             {LogicalType::INTEGER, LogicalType::BIGINT},
-                            LogicalType::BIGINT, LocalClusteringCoefficientFunction,
+                            LogicalType::FLOAT, LocalClusteringCoefficientFunction,
                             LocalClusteringCoefficientFunctionData::LocalClusteringCoefficientBind);
   return CreateScalarFunctionInfo(fun);
 }

--- a/src/functions/scalar/local_clustering_coefficient.cpp
+++ b/src/functions/scalar/local_clustering_coefficient.cpp
@@ -71,7 +71,6 @@ static void LocalClusteringCoefficientFunction(DataChunk &args, ExpressionState 
       }
     }
     float_t local_result =  static_cast<float_t>(count) / (number_of_edges * (number_of_edges - 1));
-    std::cout << src_node << " " << count << " " << number_of_edges << " " << local_result << std::endl;
     result_data[n] = local_result;
   }
 

--- a/src/functions/scalar/local_clustering_coefficient.cpp
+++ b/src/functions/scalar/local_clustering_coefficient.cpp
@@ -38,7 +38,6 @@ static void LocalClusteringCoefficientFunction(DataChunk &args, ExpressionState 
   }
   int64_t *v = (int64_t *)duckpgq_state->csr_list[info.csr_id]->v;
   vector<int64_t> &e = duckpgq_state->csr_list[info.csr_id]->e;
-  std::cout << duckpgq_state->csr_list[info.csr_id]->ToString();
   // get src and dst vectors for searches
   auto &src = args.data[1];
   UnifiedVectorFormat vdata_src;

--- a/src/functions/tablefunctions/CMakeLists.txt
+++ b/src/functions/tablefunctions/CMakeLists.txt
@@ -2,6 +2,7 @@ set(EXTENSION_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/create_property_graph.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/describe_property_graph.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/drop_property_graph.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/local_clustering_coefficient.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/match.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/pgq_scan.cpp
         ${EXTENSION_SOURCES}

--- a/src/functions/tablefunctions/local_clustering_coefficient.cpp
+++ b/src/functions/tablefunctions/local_clustering_coefficient.cpp
@@ -149,6 +149,18 @@ unique_ptr<CommonTableExpressionInfo> MakeEdgesCTE(const shared_ptr<PropertyGrap
     return result;
 }
 
+unique_ptr<CommonTableExpressionInfo> MakeUndirectedCSRCTE(const shared_ptr<PropertyGraphTable> &edge_pg_entry) {
+    auto select_node = make_uniq<SelectNode>();
+    auto select_statement = make_uniq<SelectStatement>();
+    select_statement->node = std::move(select_node);
+
+    auto result = make_uniq<CommonTableExpressionInfo>();
+    result->query = std::move(select_statement);
+
+    return result;
+}
+
+
 // Main binding function
 unique_ptr<TableRef> LocalClusteringCoefficientFunction::LocalClusteringCoefficientBindReplace(
     ClientContext &context, TableFunctionBindInput &input) {
@@ -163,8 +175,8 @@ unique_ptr<TableRef> LocalClusteringCoefficientFunction::LocalClusteringCoeffici
 
     auto select_node = CreateSelectNode(edge_pg_entry);
 
-
-    select_node->cte_map["edges_cte"] = MakeEdgesCTE(edge_pg_entry);
+    select_node->cte_map.map["edges_cte"] = MakeEdgesCTE(edge_pg_entry);
+    select_node->cte_map.map["csr_cte"] = MakeUndirectedCSRCTE(edge_pg_entry);
     auto subquery = make_uniq<SelectStatement>();
     subquery->node = std::move(select_node);
 

--- a/src/functions/tablefunctions/local_clustering_coefficient.cpp
+++ b/src/functions/tablefunctions/local_clustering_coefficient.cpp
@@ -149,10 +149,11 @@ CreateCSRCTE(const shared_ptr<PropertyGraphTable> &edge_table,
 
   vector<unique_ptr<ParsedExpression>> multiply_csr_vertex_children;
   auto two_constant = make_uniq<ConstantExpression>(Value::INTEGER(2));
-    multiply_csr_vertex_children.push_back(std::move(two_constant));
-    multiply_csr_vertex_children.push_back(std::move(sum_function));
+  multiply_csr_vertex_children.push_back(std::move(two_constant));
+  multiply_csr_vertex_children.push_back(std::move(sum_function));
 
-    auto multiply_function = make_uniq<FunctionExpression>("multiply", multiply_csr_vertex_children );
+  auto multiply_function =
+      make_uniq<FunctionExpression>("multiply", multiply_csr_vertex_children);
 
   auto inner_select_statement = make_uniq<SelectStatement>();
   auto inner_select_node = make_uniq<SelectNode>();
@@ -208,7 +209,7 @@ CreateCSRCTE(const shared_ptr<PropertyGraphTable> &edge_table,
 
   cast_select_node->from_table = std::move(inner_from_subquery);
 
-  cast_select_node->select_list.push_back(std::move(sum_function));
+  cast_select_node->select_list.push_back(std::move(multiply_function));
   auto cast_select_stmt = make_uniq<SelectStatement>();
   cast_select_stmt->node = std::move(cast_select_node);
   cast_subquery_expr->subquery = std::move(cast_select_stmt);

--- a/src/functions/tablefunctions/local_clustering_coefficient.cpp
+++ b/src/functions/tablefunctions/local_clustering_coefficient.cpp
@@ -55,7 +55,11 @@ LocalClusteringCoefficientFunction::LocalClusteringCoefficientBindReplace(
   auto lcc_function = make_uniq<FunctionExpression>(
       "local_clustering_coefficient", std::move(lcc_children));
 
-  select_expression.emplace_back(std::move(lcc_function));
+  std::vector<unique_ptr<ParsedExpression>> addition_children;
+  addition_children.emplace_back(std::move(cte_col_ref));
+  addition_children.emplace_back(std::move(lcc_function));
+  auto addition_function = make_uniq<FunctionExpression>("add", std::move(addition_children));
+  select_expression.emplace_back(std::move(addition_function));
   select_node->select_list = std::move(select_expression);
   auto src_base_ref = make_uniq<BaseTableRef>();
   src_base_ref->table_name = edge_pg_entry->source_reference;
@@ -65,7 +69,7 @@ LocalClusteringCoefficientFunction::LocalClusteringCoefficientBindReplace(
   subquery->node = std::move(select_node);
 
   auto result = make_uniq<SubqueryRef>(std::move(subquery));
-
+  result->Print(); // debug print
   return result;
 }
 

--- a/src/functions/tablefunctions/local_clustering_coefficient.cpp
+++ b/src/functions/tablefunctions/local_clustering_coefficient.cpp
@@ -5,7 +5,7 @@
 
 namespace duckdb {
 
-unique_ptr<TableRef> LocalClusteringCoefficientBindReplace(ClientContext &context,
+unique_ptr<TableRef> LocalClusteringCoefficientFunction::LocalClusteringCoefficientBindReplace(ClientContext &context,
                                              TableFunctionBindInput &input) {
   return nullptr;
 }

--- a/src/functions/tablefunctions/local_clustering_coefficient.cpp
+++ b/src/functions/tablefunctions/local_clustering_coefficient.cpp
@@ -2,75 +2,161 @@
 #include "duckdb/function/table_function.hpp"
 #include "duckpgq_extension.hpp"
 
+#include "duckdb/parser/expression/constant_expression.hpp"
+#include "duckdb/parser/expression/function_expression.hpp"
 #include <duckdb/parser/query_node/select_node.hpp>
 #include <duckdb/parser/tableref/basetableref.hpp>
 #include <duckdb/parser/tableref/subqueryref.hpp>
-#include "duckdb/parser/expression/function_expression.hpp"
-#include "duckdb/parser/expression/constant_expression.hpp"
+
+#include <duckdb/parser/tableref/joinref.hpp>
 
 namespace duckdb {
 
-unique_ptr<TableRef>
-LocalClusteringCoefficientFunction::LocalClusteringCoefficientBindReplace(
+// Utility function to transform a string to lowercase
+std::string ToLowerCase(const std::string &input) {
+    std::string result = input;
+    std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+    return result;
+}
+
+// Function to get DuckPGQState
+DuckPGQState *GetDuckPGQState(ClientContext &context) {
+    auto lookup = context.registered_state.find("duckpgq");
+    if (lookup == context.registered_state.end()) {
+        throw Exception(ExceptionType::INVALID, "Registered DuckPGQ state not found");
+    }
+    return dynamic_cast<DuckPGQState *>(lookup->second.get());
+}
+
+// Function to get PropertyGraphInfo
+CreatePropertyGraphInfo *GetPropertyGraphInfo(DuckPGQState *duckpgq_state, const std::string &pg_name) {
+    auto property_graph = duckpgq_state->registered_property_graphs.find(pg_name);
+    if (property_graph == duckpgq_state->registered_property_graphs.end()) {
+        throw Exception(ExceptionType::INVALID, "Property graph " + pg_name + " not found");
+    }
+    return dynamic_cast<CreatePropertyGraphInfo *>(property_graph->second.get());
+}
+
+// Function to validate the source node and edge table
+shared_ptr<PropertyGraphTable> ValidateSourceNodeAndEdgeTable(CreatePropertyGraphInfo *pg_info, const std::string &node_table, const std::string &edge_table) {
+    auto source_node_pg_entry = pg_info->GetTable(node_table);
+    auto edge_pg_entry = pg_info->GetTable(edge_table);
+    if (edge_pg_entry->source_reference != node_table) {
+        throw Exception(ExceptionType::INVALID, "Vertex table " + node_table + " is not a source of edge table " + edge_table);
+    }
+    return edge_pg_entry;
+}
+
+// Function to create the SELECT node
+unique_ptr<SelectNode> CreateSelectNode(const shared_ptr<PropertyGraphTable> &edge_pg_entry) {
+    auto select_node = make_uniq<SelectNode>();
+    std::vector<unique_ptr<ParsedExpression>> select_expression;
+
+    select_expression.emplace_back(make_uniq<ColumnRefExpression>(edge_pg_entry->source_pk[0], edge_pg_entry->source_reference));
+
+    auto cte_col_ref = make_uniq<ColumnRefExpression>("temp", "__x");
+
+    vector<unique_ptr<ParsedExpression>> lcc_children;
+    lcc_children.push_back(make_uniq<ConstantExpression>(Value::INTEGER(0)));
+    lcc_children.push_back(make_uniq<ColumnRefExpression>("rowid", edge_pg_entry->source_reference));
+
+    auto lcc_function = make_uniq<FunctionExpression>("local_clustering_coefficient", std::move(lcc_children));
+
+    std::vector<unique_ptr<ParsedExpression>> addition_children;
+    addition_children.emplace_back(std::move(cte_col_ref));
+    addition_children.emplace_back(std::move(lcc_function));
+
+    auto addition_function = make_uniq<FunctionExpression>("add", std::move(addition_children));
+    select_expression.emplace_back(std::move(addition_function));
+    select_node->select_list = std::move(select_expression);
+
+    auto src_base_ref = make_uniq<BaseTableRef>();
+    src_base_ref->table_name = edge_pg_entry->source_reference;
+    select_node->from_table = std::move(src_base_ref);
+
+    return select_node;
+}
+
+// Function to create the CTE for the edges
+unique_ptr<CommonTableExpressionInfo> MakeEdgesCTE(const shared_ptr<PropertyGraphTable> &edge_pg_entry) {
+    std::vector<unique_ptr<ParsedExpression>> select_expression;
+    auto src_col_ref = make_uniq<ColumnRefExpression>("rowid", edge_pg_entry->source_reference);
+    src_col_ref->alias = "src";
+    select_expression.emplace_back(std::move(src_col_ref));
+
+    auto dst_col_ref = make_uniq<ColumnRefExpression>("rowid", edge_pg_entry->destination_reference);
+    dst_col_ref->alias = "dst";
+    select_expression.emplace_back(std::move(dst_col_ref));
+
+    auto edge_col_ref = make_uniq<ColumnRefExpression>("rowid", edge_pg_entry->table_name);
+    dst_col_ref->alias = "edges";
+    select_expression.emplace_back(std::move(dst_col_ref));
+    auto select_node = make_uniq<SelectNode>();
+    select_node->select_list = std::move(select_expression);
+
+    auto edge_table_ref = make_uniq<BaseTableRef>();
+    edge_table_ref->table_name = edge_pg_entry->table_name;
+
+    auto src_table_ref = make_uniq<BaseTableRef>();
+    src_table_ref->table_name = edge_pg_entry->source_reference;
+
+    auto join_ref = make_uniq<JoinRef>(JoinRefType::REGULAR);
+
+    auto first_join_ref = make_uniq<JoinRef>(JoinRefType::REGULAR);
+    first_join_ref->type = JoinType::INNER;
+
+    first_join_ref->left = std::move(edge_table_ref);
+    first_join_ref->right = std::move(src_table_ref);
+
+    auto edge_from_ref =
+        make_uniq<ColumnRefExpression>(edge_pg_entry->source_fk[0], edge_pg_entry->table_name);
+    auto src_cid_ref =
+        make_uniq<ColumnRefExpression>(edge_pg_entry->source_pk[0], edge_pg_entry->source_reference);
+    // second_join_ref->condition = make_uniq<ComparisonExpression>(
+    //     ExpressionType::COMPARE_EQUAL, std::move(t_from_ref),
+    //     std::move(src_cid_ref));
+
+    auto second_join_ref = make_uniq<JoinRef>(JoinRefType::REGULAR);
+    second_join_ref->type = JoinType::INNER;
+
+    select_node->from_table = std::move(second_join_ref);
+
+    auto src_base_ref = make_uniq<BaseTableRef>();
+    src_base_ref->table_name = edge_pg_entry->main_label;
+    select_node->from_table = std::move(src_base_ref);
+
+    auto select_statement = make_uniq<SelectStatement>();
+    select_statement->node = std::move(select_node);
+
+    auto result = make_uniq<CommonTableExpressionInfo>();
+    result->query = std::move(select_statement);
+
+    return result;
+}
+
+// Main binding function
+unique_ptr<TableRef> LocalClusteringCoefficientFunction::LocalClusteringCoefficientBindReplace(
     ClientContext &context, TableFunctionBindInput &input) {
-  auto pg_name = StringValue::Get(input.inputs[0]);
-  std::transform(pg_name.begin(), pg_name.end(), pg_name.begin(), ::tolower);
-  auto node_table = StringValue::Get(input.inputs[1]);
-  std::transform(node_table.begin(), node_table.end(), node_table.begin(), ::tolower);
-  auto edge_table = StringValue::Get(input.inputs[2]);
-  std::transform(edge_table.begin(), edge_table.end(), edge_table.begin(), ::tolower);
 
-  auto lookup = context.registered_state.find("duckpgq");
-  if (lookup == context.registered_state.end()) {
-    throw Exception(ExceptionType::INVALID,
-                    "Registered DuckPGQ state not found");
-  }
-  const auto duckpgq_state = dynamic_cast<DuckPGQState *>(lookup->second.get());
-  auto property_graph = duckpgq_state->registered_property_graphs.find(pg_name);
-  if (property_graph == duckpgq_state->registered_property_graphs.end()) {
-    throw Exception(ExceptionType::INVALID,
-                    "Property graph " + pg_name + " not found");
-  }
-  auto pg_info =
-      dynamic_cast<CreatePropertyGraphInfo *>(property_graph->second.get());
-  auto source_node_pg_entry = pg_info->GetTable(node_table);
-  auto edge_pg_entry = pg_info->GetTable(edge_table);
-  if (edge_pg_entry->source_reference != node_table) {
-    throw Exception(ExceptionType::INVALID,
-                    "Vertex table " + node_table +
-                        " is not a source of edge table " + edge_table);
-  }
+    auto pg_name = ToLowerCase(StringValue::Get(input.inputs[0]));
+    auto node_table = ToLowerCase(StringValue::Get(input.inputs[1]));
+    auto edge_table = ToLowerCase(StringValue::Get(input.inputs[2]));
 
-  auto select_node = make_uniq<SelectNode>();
-  std::vector<unique_ptr<ParsedExpression>> select_expression;
-  select_expression.emplace_back(make_uniq<ColumnRefExpression>(edge_pg_entry->source_pk[0], edge_pg_entry->source_reference));
-  // __x.temp + local_clustering_coefficient(0, a.rowid) as lcc
+    auto duckpgq_state = GetDuckPGQState(context);
+    auto pg_info = GetPropertyGraphInfo(duckpgq_state, pg_name);
+    auto edge_pg_entry = ValidateSourceNodeAndEdgeTable(pg_info, node_table, edge_table);
 
-  auto cte_col_ref = make_uniq<ColumnRefExpression>("temp", "__x");
+    auto select_node = CreateSelectNode(edge_pg_entry);
 
-  vector<unique_ptr<ParsedExpression>> lcc_children;
-  lcc_children.push_back(make_uniq<ConstantExpression>(Value::INTEGER(0)));
-  lcc_children.push_back(make_uniq<ColumnRefExpression>("rowid", edge_pg_entry->source_reference));
 
-  auto lcc_function = make_uniq<FunctionExpression>(
-      "local_clustering_coefficient", std::move(lcc_children));
+    select_node->cte_map["edges_cte"] = MakeEdgesCTE(edge_pg_entry);
+    auto subquery = make_uniq<SelectStatement>();
+    subquery->node = std::move(select_node);
 
-  std::vector<unique_ptr<ParsedExpression>> addition_children;
-  addition_children.emplace_back(std::move(cte_col_ref));
-  addition_children.emplace_back(std::move(lcc_function));
-  auto addition_function = make_uniq<FunctionExpression>("add", std::move(addition_children));
-  select_expression.emplace_back(std::move(addition_function));
-  select_node->select_list = std::move(select_expression);
-  auto src_base_ref = make_uniq<BaseTableRef>();
-  src_base_ref->table_name = edge_pg_entry->source_reference;
-  select_node->from_table = std::move(src_base_ref);
+    auto result = make_uniq<SubqueryRef>(std::move(subquery));
+    result->Print(); // debug print
 
-  auto subquery = make_uniq<SelectStatement>();
-  subquery->node = std::move(select_node);
-
-  auto result = make_uniq<SubqueryRef>(std::move(subquery));
-  result->Print(); // debug print
-  return result;
+    return result;
 }
 
 } // namespace duckdb

--- a/src/functions/tablefunctions/local_clustering_coefficient.cpp
+++ b/src/functions/tablefunctions/local_clustering_coefficient.cpp
@@ -1,0 +1,15 @@
+#include "duckpgq/functions/tablefunctions/local_clustering_coefficient.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckpgq_extension.hpp"
+#include "duckpgq/duckpgq_functions.hpp"
+
+namespace duckdb {
+
+unique_ptr<TableRef> LocalClusteringCoefficientBindReplace(ClientContext &context,
+                                             TableFunctionBindInput &input) {
+  return nullptr;
+}
+
+
+} // namespace duckdb
+

--- a/src/functions/tablefunctions/local_clustering_coefficient.cpp
+++ b/src/functions/tablefunctions/local_clustering_coefficient.cpp
@@ -10,8 +10,11 @@ unique_ptr<TableRef>
 LocalClusteringCoefficientFunction::LocalClusteringCoefficientBindReplace(
     ClientContext &context, TableFunctionBindInput &input) {
   auto pg_name = StringValue::Get(input.inputs[0]);
+  std::transform(pg_name.begin(), pg_name.end(), pg_name.begin(), ::tolower);
   auto node_table = StringValue::Get(input.inputs[1]);
+  std::transform(node_table.begin(), node_table.end(), node_table.begin(), ::tolower);
   auto edge_table = StringValue::Get(input.inputs[2]);
+  std::transform(edge_table.begin(), edge_table.end(), edge_table.begin(), ::tolower);
 
   auto lookup = context.registered_state.find("duckpgq");
   if (lookup == context.registered_state.end()) {

--- a/src/functions/tablefunctions/local_clustering_coefficient.cpp
+++ b/src/functions/tablefunctions/local_clustering_coefficient.cpp
@@ -13,7 +13,6 @@
 #include <duckdb/parser/tableref/basetableref.hpp>
 #include <duckdb/parser/tableref/subqueryref.hpp>
 
-
 #include <duckdb/parser/tableref/joinref.hpp>
 
 namespace duckdb {
@@ -121,41 +120,59 @@ GetCountTable(const shared_ptr<PropertyGraphTable> &edge_table,
 }
 
 // Helper function to create a ColumnRefExpression with alias
-std::unique_ptr<ColumnRefExpression> CreateColumnRef(const std::string& column_name, const std::string& table_name, const std::string& alias) {
-    auto col_ref = make_uniq<ColumnRefExpression>(column_name, table_name);
-    col_ref->alias = alias;
-    return col_ref;
+std::unique_ptr<ColumnRefExpression>
+CreateColumnRef(const std::string &column_name, const std::string &table_name,
+                const std::string &alias) {
+  auto col_ref = make_uniq<ColumnRefExpression>(column_name, table_name);
+  col_ref->alias = alias;
+  return col_ref;
 }
 
 // Helper function to create a JoinRef
-std::unique_ptr<JoinRef> CreateJoin(const std::string& fk_column, const std::string& pk_column, const std::string& table_name, const std::string& source_reference) {
-    auto join = make_uniq<JoinRef>(JoinRefType::REGULAR);
-    join->type = JoinType::INNER;
-    join->condition = make_uniq<ComparisonExpression>(
-        ExpressionType::COMPARE_EQUAL,
-        make_uniq<ColumnRefExpression>(fk_column, table_name),
-        make_uniq<ColumnRefExpression>(pk_column, source_reference));
-    return join;
+std::unique_ptr<JoinRef> CreateJoin(const std::string &fk_column,
+                                    const std::string &pk_column,
+                                    const std::string &table_name,
+                                    const std::string &source_reference) {
+  auto join = make_uniq<JoinRef>(JoinRefType::REGULAR);
+  join->type = JoinType::INNER;
+  join->condition = make_uniq<ComparisonExpression>(
+      ExpressionType::COMPARE_EQUAL,
+      make_uniq<ColumnRefExpression>(fk_column, table_name),
+      make_uniq<ColumnRefExpression>(pk_column, source_reference));
+  return join;
 }
 
 // Helper function to setup SelectNode
-void SetupSelectNode(unique_ptr<SelectNode>& select_node, const shared_ptr<PropertyGraphTable>& edge_table, bool reverse = false) {
-    select_node = make_uniq<SelectNode>();
+void SetupSelectNode(unique_ptr<SelectNode> &select_node,
+                     const shared_ptr<PropertyGraphTable> &edge_table,
+                     bool reverse = false) {
+  select_node = make_uniq<SelectNode>();
 
-    select_node->select_list.emplace_back(CreateColumnRef("rowid", edge_table->source_reference, "dense_id"));
-    if (!reverse) {
-        select_node->select_list.emplace_back(CreateColumnRef(edge_table->source_fk[0], edge_table->table_name, "outgoing_edges"));
-        select_node->select_list.emplace_back(CreateColumnRef(edge_table->destination_fk[0], edge_table->table_name, "incoming_edges"));
-        select_node->from_table = CreateJoin(edge_table->source_fk[0], edge_table->source_pk[0], edge_table->table_name, edge_table->source_reference);
-    } else {
-        select_node->select_list.emplace_back(CreateColumnRef(edge_table->destination_fk[0], edge_table->table_name, "outgoing_edges"));
-        select_node->select_list.emplace_back(CreateColumnRef(edge_table->source_fk[0], edge_table->table_name, "incoming_edges"));
-        select_node->from_table = CreateJoin(edge_table->destination_fk[0], edge_table->source_pk[0], edge_table->table_name, edge_table->source_reference);
-    }
+  select_node->select_list.emplace_back(
+      CreateColumnRef("rowid", edge_table->source_reference, "dense_id"));
+  if (!reverse) {
+    select_node->select_list.emplace_back(CreateColumnRef(
+        edge_table->source_fk[0], edge_table->table_name, "outgoing_edges"));
+    select_node->select_list.emplace_back(
+        CreateColumnRef(edge_table->destination_fk[0], edge_table->table_name,
+                        "incoming_edges"));
+    select_node->from_table =
+        CreateJoin(edge_table->source_fk[0], edge_table->source_pk[0],
+                   edge_table->table_name, edge_table->source_reference);
+  } else {
+    select_node->select_list.emplace_back(
+        CreateColumnRef(edge_table->destination_fk[0], edge_table->table_name,
+                        "outgoing_edges"));
+    select_node->select_list.emplace_back(CreateColumnRef(
+        edge_table->source_fk[0], edge_table->table_name, "incoming_edges"));
+    select_node->from_table =
+        CreateJoin(edge_table->destination_fk[0], edge_table->source_pk[0],
+                   edge_table->table_name, edge_table->source_reference);
+  }
 
-    vector<unique_ptr<ResultModifier>> modifiers;
-    modifiers.emplace_back(make_uniq<DistinctModifier>());
-    select_node->modifiers = std::move(modifiers);
+  vector<unique_ptr<ResultModifier>> modifiers;
+  modifiers.emplace_back(make_uniq<DistinctModifier>());
+  select_node->modifiers = std::move(modifiers);
 }
 
 unique_ptr<CommonTableExpressionInfo>
@@ -193,8 +210,8 @@ CreateCSRCTE(const shared_ptr<PropertyGraphTable> &edge_table,
   multiply_csr_vertex_children.push_back(std::move(two_constant));
   multiply_csr_vertex_children.push_back(std::move(sum_function));
 
-  auto multiply_function =
-      make_uniq<FunctionExpression>("multiply", std::move(multiply_csr_vertex_children));
+  auto multiply_function = make_uniq<FunctionExpression>(
+      "multiply", std::move(multiply_csr_vertex_children));
 
   auto inner_select_statement = make_uniq<SelectStatement>();
   auto inner_select_node = make_uniq<SelectNode>();
@@ -215,31 +232,31 @@ CreateCSRCTE(const shared_ptr<PropertyGraphTable> &edge_table,
 
   inner_select_node->select_list.push_back(std::move(source_rowid_colref));
   inner_select_node->select_list.push_back(std::move(inner_count_function));
-    // so far so good
 
-    auto dense_id_colref = make_uniq<ColumnRefExpression>("dense_id");
+  auto dense_id_colref = make_uniq<ColumnRefExpression>("dense_id");
   expression_map_t<idx_t> grouping_expression_map;
   inner_select_node->groups.group_expressions.push_back(
       std::move(dense_id_colref));
   GroupingSet grouping_set = {0};
   inner_select_node->groups.grouping_sets.push_back(grouping_set);
 
-    unique_ptr<SelectNode> unique_edges_select_node, unique_edges_select_node_reverse;
+  unique_ptr<SelectNode> unique_edges_select_node,
+      unique_edges_select_node_reverse;
 
-    SetupSelectNode(unique_edges_select_node, edge_table);
-    SetupSelectNode(unique_edges_select_node_reverse, edge_table, true);
-    // UNION ALL
-    auto union_all_node = make_uniq<SetOperationNode>();
-    union_all_node->setop_all = true;
-    union_all_node->setop_type = SetOperationType::UNION;
-    union_all_node->left = std::move(unique_edges_select_node);
-    union_all_node->right = std::move(unique_edges_select_node_reverse);
+  SetupSelectNode(unique_edges_select_node, edge_table);
+  SetupSelectNode(unique_edges_select_node_reverse, edge_table, true);
+  // UNION ALL
+  auto union_all_node = make_uniq<SetOperationNode>();
+  union_all_node->setop_all = true;
+  union_all_node->setop_type = SetOperationType::UNION;
+  union_all_node->left = std::move(unique_edges_select_node);
+  union_all_node->right = std::move(unique_edges_select_node_reverse);
 
-    auto subquery_select_statement = make_uniq<SelectStatement>();
-    subquery_select_statement->node = std::move(union_all_node);
-    auto unique_edges_subquery = make_uniq<SubqueryRef>();
-    unique_edges_subquery->subquery = std::move(subquery_select_statement);
-    unique_edges_subquery->alias = "unique_edges";
+  auto subquery_select_statement = make_uniq<SelectStatement>();
+  subquery_select_statement->node = std::move(union_all_node);
+  auto unique_edges_subquery = make_uniq<SubqueryRef>();
+  unique_edges_subquery->subquery = std::move(subquery_select_statement);
+  unique_edges_subquery->alias = "unique_edges";
   //
   // auto inner_join_ref = make_uniq<JoinRef>(JoinRefType::REGULAR);
   // inner_join_ref->type = JoinType::LEFT;

--- a/src/functions/tablefunctions/local_clustering_coefficient.cpp
+++ b/src/functions/tablefunctions/local_clustering_coefficient.cpp
@@ -52,7 +52,13 @@ ValidateSourceNodeAndEdgeTable(CreatePropertyGraphInfo *pg_info,
                                const std::string &node_table,
                                const std::string &edge_table) {
   auto source_node_pg_entry = pg_info->GetTable(node_table);
+  if (source_node_pg_entry->is_vertex_table == false) {
+    throw Exception(ExceptionType::INVALID, node_table + " is an edge table, expected a vertex table");
+  }
   auto edge_pg_entry = pg_info->GetTable(edge_table);
+  if (edge_pg_entry->is_vertex_table) {
+    throw Exception(ExceptionType::INVALID, edge_table + " is a vertex table, expected an edge table");
+  }
   if (edge_pg_entry->source_reference != node_table) {
     throw Exception(ExceptionType::INVALID,
                     "Vertex table " + node_table +

--- a/src/functions/tablefunctions/local_clustering_coefficient.cpp
+++ b/src/functions/tablefunctions/local_clustering_coefficient.cpp
@@ -59,7 +59,7 @@ ValidateSourceNodeAndEdgeTable(CreatePropertyGraphInfo *pg_info,
   if (edge_pg_entry->is_vertex_table) {
     throw Exception(ExceptionType::INVALID, edge_table + " is a vertex table, expected an edge table");
   }
-  if (edge_pg_entry->source_reference != node_table) {
+  if (!edge_pg_entry->IsSourceTable(node_table)) {
     throw Exception(ExceptionType::INVALID,
                     "Vertex table " + node_table +
                         " is not a source of edge table " + edge_table);

--- a/src/functions/tablefunctions/local_clustering_coefficient.cpp
+++ b/src/functions/tablefunctions/local_clustering_coefficient.cpp
@@ -1,15 +1,40 @@
 #include "duckpgq/functions/tablefunctions/local_clustering_coefficient.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckpgq_extension.hpp"
-#include "duckpgq/duckpgq_functions.hpp"
+
+#include <duckdb/parser/tableref/subqueryref.hpp>
 
 namespace duckdb {
 
-unique_ptr<TableRef> LocalClusteringCoefficientFunction::LocalClusteringCoefficientBindReplace(ClientContext &context,
-                                             TableFunctionBindInput &input) {
+unique_ptr<TableRef>
+LocalClusteringCoefficientFunction::LocalClusteringCoefficientBindReplace(
+    ClientContext &context, TableFunctionBindInput &input) {
+  auto pg_name = StringValue::Get(input.inputs[0]);
+  auto node_table = StringValue::Get(input.inputs[1]);
+  auto edge_table = StringValue::Get(input.inputs[2]);
+
+  auto lookup = context.registered_state.find("duckpgq");
+  if (lookup == context.registered_state.end()) {
+    throw Exception(ExceptionType::INVALID,
+                    "Registered DuckPGQ state not found");
+  }
+  const auto duckpgq_state = dynamic_cast<DuckPGQState *>(lookup->second.get());
+  auto property_graph = duckpgq_state->registered_property_graphs.find(pg_name);
+  if (property_graph == duckpgq_state->registered_property_graphs.end()) {
+    throw Exception(ExceptionType::INVALID,
+                    "Property graph " + pg_name + " not found");
+  }
+  auto pg_info =
+      dynamic_cast<CreatePropertyGraphInfo *>(property_graph->second.get());
+  auto source_node_pg_entry = pg_info->GetTable(node_table);
+  auto edge_pg_entry = pg_info->GetTable(edge_table);
+  if (edge_pg_entry->source_reference != node_table) {
+    throw Exception(ExceptionType::INVALID,
+                    "Vertex table " + node_table +
+                        " is not a source of edge table " + edge_table);
+  }
+
   return nullptr;
 }
 
-
 } // namespace duckdb
-

--- a/src/functions/tablefunctions/match.cpp
+++ b/src/functions/tablefunctions/match.cpp
@@ -514,7 +514,7 @@ PathElement *PGQMatchFunction::HandleNestedSubPath(
 }
 
 unique_ptr<ParsedExpression>
-CreateWhereClause(vector<unique_ptr<ParsedExpression>> &conditions) {
+PGQMatchFunction::CreateWhereClause(vector<unique_ptr<ParsedExpression>> &conditions) {
   unique_ptr<ParsedExpression> where_clause;
   for (auto &condition : conditions) {
     if (where_clause) {

--- a/src/include/duckpgq/common.hpp
+++ b/src/include/duckpgq/common.hpp
@@ -29,6 +29,7 @@ public:
 
 private:
   std::vector<uint64_t> bitmap;
+  size_t size;
 };
 
 

--- a/src/include/duckpgq/common.hpp
+++ b/src/include/duckpgq/common.hpp
@@ -28,9 +28,7 @@ public:
   void reset();
 
 private:
-  size_t size;
   std::vector<uint64_t> bitmap;
-
 };
 
 

--- a/src/include/duckpgq/common.hpp
+++ b/src/include/duckpgq/common.hpp
@@ -20,6 +20,21 @@
 
 namespace duckdb {
 
+class DuckPGQBitmap {
+public:
+  explicit DuckPGQBitmap(size_t size);
+  void set(size_t index);
+  bool test(size_t index) const;
+  void reset();
+
+private:
+  size_t size;
+  std::vector<uint64_t> bitmap;
+
+};
+
+
+
 struct CSRFunctionData : public FunctionData {
 public:
   CSRFunctionData(ClientContext &context, int32_t id, LogicalType weight_type);

--- a/src/include/duckpgq/common.hpp
+++ b/src/include/duckpgq/common.hpp
@@ -42,6 +42,22 @@ public:
                                  // when no type is provided
 };
 
+struct LocalClusteringCoefficientFunctionData : public FunctionData {
+public:
+  ClientContext &context;
+  int32_t csr_id;
+
+  LocalClusteringCoefficientFunctionData(ClientContext &context, int32_t csr_id)
+      : context(context), csr_id(csr_id) {}
+  static unique_ptr<FunctionData>
+  LocalClusteringCoefficientBind(ClientContext &context, ScalarFunction &bound_function,
+                      vector<unique_ptr<Expression>> &arguments);
+
+  unique_ptr<FunctionData> Copy() const override;
+  bool Equals(const FunctionData &other_p) const override;
+};
+
+
 struct IterativeLengthFunctionData : public FunctionData {
 public:
   ClientContext &context;

--- a/src/include/duckpgq/compressed_sparse_row.hpp
+++ b/src/include/duckpgq/compressed_sparse_row.hpp
@@ -22,5 +22,31 @@ public:
   bool initialized_w = false;
 
   size_t vsize;
+
+  string ToString() {
+    string result;
+    if (initialized_v) {
+      result += "v: ";
+      for (size_t i = 0; i < vsize; i++) {
+        result += to_string(v[i].load()) + " ";
+      }
+    }
+    result += "\n";
+    if (initialized_e) {
+      result += "e: ";
+      for (size_t i = 0; i < e.size(); i++) {
+        result += to_string(e[i]) + " ";
+      }
+    }
+    result += "\n";
+    if (initialized_w) {
+      result += "w: ";
+      for (size_t i = 0; i < w.size(); i++) {
+        result += to_string(w[i]) + " ";
+      }
+    }
+    return result;
+  };
+
 };
 } // namespace duckdb

--- a/src/include/duckpgq/duckpgq_functions.hpp
+++ b/src/include/duckpgq/duckpgq_functions.hpp
@@ -33,6 +33,7 @@ public:
     functions.push_back(GetIterativeLength2Function());
     functions.push_back(GetDeleteCsrFunction());
     functions.push_back(GetGetCsrWTypeFunction());
+    functions.push_back(GetLocalClusteringCoefficientFunction());
 
     return functions;
   }
@@ -63,6 +64,7 @@ private:
   static CreateScalarFunctionInfo GetIterativeLength2Function();
   static CreateScalarFunctionInfo GetDeleteCsrFunction();
   static CreateScalarFunctionInfo GetGetCsrWTypeFunction();
+  static CreateScalarFunctionInfo GetLocalClusteringCoefficientFunction();
 
   static void AddAliases(vector<string> names, CreateScalarFunctionInfo fun,
                          vector<CreateScalarFunctionInfo> &functions) {

--- a/src/include/duckpgq/duckpgq_functions.hpp
+++ b/src/include/duckpgq/duckpgq_functions.hpp
@@ -10,7 +10,6 @@
 
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
-#include "duckdb/main/extension_util.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckpgq/functions/tablefunctions/local_clustering_coefficient.hpp
+++ b/src/include/duckpgq/functions/tablefunctions/local_clustering_coefficient.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "duckdb/function/table_function.hpp"
+#include "duckpgq/common.hpp"
+#include "duckpgq/duckpgq_functions.hpp"
+
+namespace duckdb {
+class LocalClusteringCoefficientFunction : public TableFunction {
+public:
+  LocalClusteringCoefficientFunction() {
+    name = "local_clustering_coefficient";
+    arguments = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+    bind_replace = LocalClusteringCoefficientBindReplace;
+  }
+
+  static unique_ptr<TableRef> LocalClusteringCoefficientBindReplace(ClientContext &context,
+                                             TableFunctionBindInput &input);
+
+  };
+
+ struct LocalClusteringCoefficientData : TableFunctionData {
+   static unique_ptr<FunctionData>
+   LocalClusteringCoefficientBind(ClientContext &context, TableFunctionBindInput &input,
+                  vector<LogicalType> &return_types, vector<string> &names) {
+     auto result = make_uniq<LocalClusteringCoefficientData>();
+     result->pg_name = StringValue::Get(input.inputs[0]);
+     result->node_table = StringValue::Get(input.inputs[1]);
+     result->edge_table = StringValue::Get(input.inputs[2]);
+     return_types.emplace_back(LogicalType::BIGINT);
+     return_types.emplace_back(LogicalType::FLOAT);
+     names.emplace_back("rowid");
+     names.emplace_back("local_clustering_coefficient");
+     return std::move(result);
+   }
+
+   string pg_name;
+   string node_table;
+   string edge_table;
+ };
+
+
+ struct LocalClusteringCoefficientScanState :  GlobalTableFunctionState {
+   static unique_ptr<GlobalTableFunctionState>
+   Init(ClientContext &context, TableFunctionInitInput &input) {
+     auto result = make_uniq<LocalClusteringCoefficientScanState>();
+     return std::move(result);
+   }
+
+   bool finished = false;
+};
+
+
+}

--- a/src/include/duckpgq/functions/tablefunctions/match.hpp
+++ b/src/include/duckpgq/functions/tablefunctions/match.hpp
@@ -12,8 +12,8 @@
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/parser/parsed_data/create_property_graph_info.hpp"
 #include "duckdb/parser/path_element.hpp"
-#include "duckdb/parser/subpath_element.hpp"
 #include "duckdb/parser/path_pattern.hpp"
+#include "duckdb/parser/subpath_element.hpp"
 
 namespace duckdb {
 struct PGQMatchFunction : public TableFunction {
@@ -63,6 +63,9 @@ public:
   CreateCSRCTE(const shared_ptr<PropertyGraphTable> &edge_table,
                const string &edge_binding, const string &prev_binding,
                const string &next_binding);
+
+  static unique_ptr<ParsedExpression>
+  CreateWhereClause(vector<unique_ptr<ParsedExpression>> &conditions);
 
   static void EdgeTypeAny(const shared_ptr<PropertyGraphTable> &edge_table,
                           const string &edge_binding,

--- a/test/sql/scalar/local_clustering_coefficient.test
+++ b/test/sql/scalar/local_clustering_coefficient.test
@@ -1,0 +1,43 @@
+# name: test/sql/scalar/local_clustering_coefficient.test
+# group: [duckpgq]
+
+require duckpgq
+
+statement ok
+CREATE TABLE Student(id BIGINT, name VARCHAR);INSERT INTO Student VALUES (0, 'Daniel'), (1, 'Tavneet'), (2, 'Gabor'), (3, 'Peter'), (4, 'David');
+
+statement ok
+CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (3,0, 13), (1,2, 14), (1,3, 15), (2,3, 16), (4,3, 17);
+
+query III
+WITH cte1 AS (
+    SELECT  CREATE_CSR_EDGE(
+            0,
+            (SELECT count(a.id) FROM Student a),
+            CAST (
+                (SELECT sum(CREATE_CSR_VERTEX(
+                            0,
+                            (SELECT count(a.id) FROM Student a),
+                            sub.dense_id,
+                            sub.cnt)
+                            )
+                FROM (
+                    SELECT a.rowid as dense_id, count(k.src) as cnt
+                    FROM Student a
+                    LEFT JOIN Know k ON k.src = a.id
+                    GROUP BY a.rowid) sub
+                )
+            AS BIGINT),
+            a.rowid,
+            c.rowid,
+            k.rowid) as temp
+    FROM Know k
+    JOIN student a on a.id = k.src
+    JOIN student c on c.id = k.dst
+) SELECT local_clustering_coefficient(0, a.rowid) as path, a.name as a_name, b.name as b_name
+        FROM student a, student b, (select count(cte1.temp) * 0 as temp from cte1) __x
+----
+[0, 0, 1]	Daniel	Tavneet
+[0, 1, 2]	Daniel	Gabor
+[0, 2, 3]	Daniel	Peter
+

--- a/test/sql/scalar/local_clustering_coefficient.test
+++ b/test/sql/scalar/local_clustering_coefficient.test
@@ -10,9 +10,13 @@ statement ok
 CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (3,0, 13), (1,2, 14), (1,3, 15), (2,3, 16), (4,3, 17);
 
 statement ok
+CREATE TABLE Foo(id BIGINT);INSERT INTO Foo VALUES (0), (1), (2), (3), (4);
+
+statement ok
 -CREATE PROPERTY GRAPH pg
 VERTEX TABLES (
-    Student
+    Student,
+    Foo
     )
 EDGE TABLES (
     know    SOURCE KEY ( src ) REFERENCES Student ( id )
@@ -88,6 +92,31 @@ select a.id, a.name, local_clustering_coefficient from local_clustering_coeffici
 2	Gabor	1.0
 3	Peter	0.5
 4	David	0.0
+
+statement error
+select local_clustering_coefficient from local_clustering_coefficient(pgdoesnotexist, student, know), student a where a.id = lcc.id;
+----
+Invalid Error: Property graph pgdoesnotexist not found
+
+statement error
+select local_clustering_coefficient from local_clustering_coefficient(pg, a, know), student a where a.id = lcc.id;
+----
+Invalid Error: Table a not found in property graph pg
+
+statement error
+select local_clustering_coefficient from local_clustering_coefficient(pg, student, b), student a where a.id = lcc.id;
+----
+Invalid Error: Table b not found in property graph pg
+
+statement error
+select local_clustering_coefficient from local_clustering_coefficient(pg, foo, student), student a where a.id = lcc.id;
+----
+Invalid Error: student is a vertex table, expected an edge table
+
+statement error
+select local_clustering_coefficient from local_clustering_coefficient(pg, student, foo), student a where a.id = lcc.id;
+----
+Invalid Error: foo is a vertex table, expected an edge table
 
 statement ok
 import database 'duckdb-pgq/data/SNB0.003';

--- a/test/sql/scalar/local_clustering_coefficient.test
+++ b/test/sql/scalar/local_clustering_coefficient.test
@@ -19,6 +19,9 @@ EDGE TABLES (
             DESTINATION KEY ( dst ) REFERENCES Student ( id )
     );
 
+statement ok
+select * from local_clustering_coefficient(pg, student, know);
+
 query II
 WITH cte1 AS (
     SELECT  CREATE_CSR_EDGE(
@@ -286,3 +289,4 @@ WITH cte1 AS (
 35184372088871	0.0
 37383395344394	0.0
 37383395344409	0.0
+

--- a/test/sql/scalar/local_clustering_coefficient.test
+++ b/test/sql/scalar/local_clustering_coefficient.test
@@ -19,7 +19,7 @@ EDGE TABLES (
             DESTINATION KEY ( dst ) REFERENCES Student ( id )
     );
 
-query III
+query II
 WITH cte1 AS (
     SELECT  CREATE_CSR_EDGE(
             0,
@@ -30,24 +30,282 @@ WITH cte1 AS (
                             (SELECT count(a.id) FROM Student a),
                             sub.dense_id,
                             sub.cnt)
+                            ) * 2
+                FROM (
+                    SELECT a.rowid as dense_id, count(k.src) * 2 as cnt
+                    FROM (SELECT a.rowid as dense_id FROM Student a
+                            LEFT JOIN Know k ON k.src = a.id
+                            GROUP BY a.rowid) sub
+                )
+            AS BIGINT),
+            src,
+            dst,
+            edge) as temp FROM (
+    select src, dst, any_value(edge) as edge FROM (
+        select a.rowid as src, c.rowid as dst, k.rowid as edge FROM Know k
+        JOIN Student a on a.id = k.src
+        JOIN Student c on c.id = k.dst
+        UNION ALL
+        select a.rowid as src, c.rowid as dst, k.rowid as edge FROM Know k
+        JOIN Student a on a.id = k.dst
+        JOIN Student c on c.id = k.src)
+    GROUP BY src, dst)
+) SELECT __x.temp + local_clustering_coefficient(0, a.rowid) as lcc, a.name
+        FROM (select count(cte1.temp) * 0 as temp from cte1) __x, Student a
+        ORDER BY lcc DESC;
+----
+0.5	Daniel
+0.5	Tavneet
+0.0	Gabor
+0.0	Peter
+0.0	David
+
+
+#statement ok
+#CREATE TABLE Node(id BIGINT);INSERT INTO Node VALUES (0), (1), (2), (3);
+#
+#statement ok
+#CREATE TABLE Edge(src BIGINT, dst BIGINT);INSERT INTO Edge VALUES (0,1), (0,2), (0,3), (1,0), (1,2), (1,3), (2,0), (2,1), (2,3), (3,0), (3,1), (3,2);
+
+#query III
+#WITH cte1 AS (
+#    SELECT  CREATE_CSR_EDGE(
+#            0,
+#            (SELECT count(a.id) FROM Edge a),
+#            CAST (
+#                (SELECT sum(CREATE_CSR_VERTEX(
+#                            0,
+#                            (SELECT count(a.id) FROM Node a),
+#                            sub.dense_id,
+#                            sub.cnt)
+#                            )
+#                FROM (
+#                    SELECT a.rowid as dense_id, count(k.src) as cnt
+#                    FROM Node a
+#                    LEFT JOIN Edge k ON k.src = a.id
+#                    GROUP BY a.rowid) sub
+#                )
+#            AS BIGINT),
+#            a.rowid,
+#            c.rowid,
+#            k.rowid) as temp
+#    FROM Edge k
+#    JOIN Node a on a.id = k.src
+#    JOIN Node c on c.id = k.dst
+#) SELECT __x.temp + local_clustering_coefficient(0, a.rowid) as lcc, a.name as a_name
+#        FROM (select count(cte1.temp) * 0 as temp from cte1) __x, Node a
+#----
+#[0, 0, 1]	Daniel	Tavneet
+#[0, 1, 2]	Daniel	Gabor
+#[0, 2, 3]	Daniel	Peter
+
+
+statement ok
+import database '~/git/duckpgq-experiments/data/SNB1-projected|';
+
+#query II
+#WITH neighbors AS (
+#    SELECT
+#        person1id AS id,
+#        person2id AS neighbor
+#    FROM
+#        person_knows_person
+#    UNION ALL
+#    SELECT
+#        person2id AS id,
+#        person1id AS neighbor
+#    FROM
+#        person_knows_person
+#),
+#in_degree AS (
+#    SELECT
+#        id,
+#        COUNT(DISTINCT neighbor) AS in_degree
+#    FROM
+#        neighbors
+#    GROUP BY
+#        id
+#),
+#out_degree AS (
+#    SELECT
+#        person1id AS id,
+#        COUNT(DISTINCT person2id) AS out_degree
+#    FROM
+#        person_knows_person
+#    GROUP BY
+#        person1id
+#),
+#triangles AS (
+#    SELECT
+#        pkp1.person1id AS id,
+#        COUNT(DISTINCT pkp2.person2id) AS triangle_count
+#    FROM
+#        person_knows_person pkp1
+#    JOIN
+#        person_knows_person pkp2 ON pkp1.person2id = pkp2.person1id
+#    JOIN
+#        person_knows_person pkp3 ON pkp2.person2id = pkp3.person2id AND pkp1.person1id = pkp3.person1id
+#    GROUP BY
+#        pkp1.person1id
+#),
+#local_clustering_coefficient AS (
+#    SELECT
+#        id,
+#        in_degree + out_degree AS degree,
+#        triangle_count,
+#        CASE
+#            WHEN (in_degree + out_degree) > 1 THEN 1.0 * triangle_count / ((in_degree + out_degree) * (in_degree + out_degree - 1))
+#            ELSE 0.0
+#        END AS local_clustering_coefficient
+#    FROM
+#        in_degree
+#    JOIN
+#        out_degree USING (id)
+#    LEFT JOIN
+#        triangles USING (id)
+#)
+#SELECT
+#    id,
+#    local_clustering_coefficient
+#FROM
+#    local_clustering_coefficient
+#ORDER BY
+#    local_clustering_coefficient DESC;
+#----
+#0.5	Arbaaz
+#0.5	Lei
+#0.5	Almira
+#0.5	Alexei
+#0.41666666	Miguel
+#0.33333334	Eric
+#0.25	Jan
+#0.2	John
+#0.2	Ken
+#0.16666667	Hossein
+#0.14285715	Celso
+#0.102564104	Ali
+#0.083333336	Evangelos
+#0.06666667	Alim
+#0.0	Ayesha
+#0.0	Alejandro
+#0.0	Rahul
+#0.0	John
+#0.0	John
+#0.0	Adje van den Berg
+#0.0	Joakim
+#0.0	Rahul
+#0.0	Mehmet
+#0.0	Wojciech
+#0.0	Ali
+#0.0	John
+#0.0	Jimmy
+#0.0	Baby
+#0.0	Jun
+#0.0	Wei
+#0.0	Djelaludin
+#0.0	Otto
+#0.0	Roberto
+#0.0	Bryn
+#0.0	Ge
+#0.0	Yahya Ould Ahmed El
+#0.0	Hans
+#0.0	Ali
+#0.0	Tissa
+#0.0	Aleksandr
+#0.0	Jose
+#0.0	Cheng
+#0.0	Alfonso
+#0.0	Ashok
+#0.0	Abdul Haris
+#0.0	Neil
+#0.0	Jie
+#0.0	Alexei
+#0.0	Wolfgang
+#0.0	Luigi
+#
+#
+
+query II
+WITH cte1 AS (
+    SELECT  CREATE_CSR_EDGE(
+            0,
+            (SELECT count(a.id) * 2 FROM Person a),
+            CAST (
+                (SELECT sum(CREATE_CSR_VERTEX(
+                            0,
+                            (SELECT count(a.id) * 2 FROM Person a),
+                            sub.dense_id,
+                            sub.cnt)
                             )
                 FROM (
-                    SELECT a.rowid as dense_id, count(k.src) as cnt
-                    FROM Student a
-                    LEFT JOIN Know k ON k.src = a.id
+                    SELECT a.rowid as dense_id, count(k.person1id) as cnt
+                    FROM Person a
+                    LEFT JOIN Person_knows_person k ON k.person1id = a.id
                     GROUP BY a.rowid) sub
                 )
             AS BIGINT),
-            a.rowid,
-            c.rowid,
-            k.rowid) as temp
-    FROM Know k
-    JOIN student a on a.id = k.src
-    JOIN student c on c.id = k.dst
-) SELECT __x.temp + local_clustering_coefficient(0, a.rowid) as path, a.name as a_name, b.name as b_name
-        FROM (select count(cte1.temp) * 0 as temp from cte1) __x, student a, student b
+            src,
+            dst,
+            edge) as temp FROM (
+    select src, dst, edge FROM (
+        select a.rowid as src, c.rowid as dst, k.rowid as edge FROM Person_knows_person k
+        JOIN Person a on a.id = k.person1id
+        JOIN Person c on c.id = k.person2id
+        UNION ALL
+        select a.rowid as src, c.rowid as dst, k.rowid as edge FROM Person_knows_person k
+        JOIN Person a on a.id = k.person2id
+        JOIN Person c on c.id = k.person1id))
+) SELECT __x.temp + local_clustering_coefficient(0, a.rowid) as lcc, a.id as a_name
+        FROM (select count(cte1.temp) * 0 as temp from cte1) __x, Person a
+        ORDER BY lcc DESC;
 ----
-[0, 0, 1]	Daniel	Tavneet
-[0, 1, 2]	Daniel	Gabor
-[0, 2, 3]	Daniel	Peter
-
+0.5	Arbaaz
+0.5	Lei
+0.5	Almira
+0.5	Alexei
+0.41666666	Miguel
+0.33333334	Eric
+0.25	Jan
+0.2	John
+0.2	Ken
+0.16666667	Hossein
+0.14285715	Celso
+0.102564104	Ali
+0.083333336	Evangelos
+0.06666667	Alim
+0.0	Ayesha
+0.0	Alejandro
+0.0	Rahul
+0.0	John
+0.0	John
+0.0	Adje van den Berg
+0.0	Joakim
+0.0	Rahul
+0.0	Mehmet
+0.0	Wojciech
+0.0	Ali
+0.0	John
+0.0	Jimmy
+0.0	Baby
+0.0	Jun
+0.0	Wei
+0.0	Djelaludin
+0.0	Otto
+0.0	Roberto
+0.0	Bryn
+0.0	Ge
+0.0	Yahya Ould Ahmed El
+0.0	Hans
+0.0	Ali
+0.0	Tissa
+0.0	Aleksandr
+0.0	Jose
+0.0	Cheng
+0.0	Alfonso
+0.0	Ashok
+0.0	Abdul Haris
+0.0	Neil
+0.0	Jie
+0.0	Alexei
+0.0	Wolfgang
+0.0	Luigi

--- a/test/sql/scalar/local_clustering_coefficient.test
+++ b/test/sql/scalar/local_clustering_coefficient.test
@@ -9,6 +9,16 @@ CREATE TABLE Student(id BIGINT, name VARCHAR);INSERT INTO Student VALUES (0, 'Da
 statement ok
 CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (3,0, 13), (1,2, 14), (1,3, 15), (2,3, 16), (4,3, 17);
 
+statement ok
+-CREATE PROPERTY GRAPH pg
+VERTEX TABLES (
+    Student
+    )
+EDGE TABLES (
+    know    SOURCE KEY ( src ) REFERENCES Student ( id )
+            DESTINATION KEY ( dst ) REFERENCES Student ( id )
+    );
+
 query III
 WITH cte1 AS (
     SELECT  CREATE_CSR_EDGE(
@@ -34,8 +44,8 @@ WITH cte1 AS (
     FROM Know k
     JOIN student a on a.id = k.src
     JOIN student c on c.id = k.dst
-) SELECT local_clustering_coefficient(0, a.rowid) as path, a.name as a_name, b.name as b_name
-        FROM student a, student b, (select count(cte1.temp) * 0 as temp from cte1) __x
+) SELECT __x.temp + local_clustering_coefficient(0, a.rowid) as path, a.name as a_name, b.name as b_name
+        FROM (select count(cte1.temp) * 0 as temp from cte1) __x, student a, student b
 ----
 [0, 0, 1]	Daniel	Tavneet
 [0, 1, 2]	Daniel	Gabor

--- a/test/sql/scalar/local_clustering_coefficient.test
+++ b/test/sql/scalar/local_clustering_coefficient.test
@@ -19,14 +19,6 @@ EDGE TABLES (
             DESTINATION KEY ( dst ) REFERENCES Student ( id )
     );
 
-query II
-select * from local_clustering_coefficient(pg, student, know);
-----
-1.0	Daniel
-1.0	Tavneet
-1.0	Gabor
-0.5	Peter
-0.0	David
 
 
 
@@ -78,6 +70,16 @@ WITH cte1 AS (
 1.0	Gabor
 0.5	Peter
 0.0	David
+
+query II
+select * from local_clustering_coefficient(pg, student, know);
+----
+1.0	Daniel
+1.0	Tavneet
+1.0	Gabor
+0.5	Peter
+0.0	David
+
 
 statement ok
 import database 'duckdb-pgq/data/SNB0.003';

--- a/test/sql/scalar/local_clustering_coefficient.test
+++ b/test/sql/scalar/local_clustering_coefficient.test
@@ -298,3 +298,198 @@ WITH cte1 AS (
 37383395344394	0.0
 37383395344409	0.0
 
+query II
+WITH edges_cte AS (
+    SELECT a.rowid as src, c.rowid as dst, k.rowid as edges
+    FROM Person_knows_person k
+    JOIN Person a on a.id = k.person1id
+    JOIN Person c on c.id = k.person2id
+),
+cte1 AS (
+    SELECT  CREATE_CSR_EDGE(
+            0,
+            (SELECT count(a.id) FROM Person a),
+            CAST (
+                (SELECT sum(CREATE_CSR_VERTEX(
+                            0,
+                            (SELECT count(a.id) FROM Person a),
+                            sub.dense_id,
+                            sub.cnt)
+                            ) * 2
+                FROM (
+                    SELECT dense_id, count(*) as cnt FROM (
+                        SELECT dense_id, outgoing_edge, incoming_edge
+                            FROM (
+                                SELECT a.rowid AS dense_id, k.person1id AS outgoing_edge, k.person2id AS incoming_edge
+                                FROM Person a
+                                JOIN Person_knows_person k ON k.person1id = a.id
+                                UNION ALL
+                                SELECT a.rowid AS dense_id, k.person2id AS outgoing_edge, k.person1id AS incoming_edge
+                                FROM Person a
+                                JOIN Person_knows_person k on k.person2id = a.id)
+                        GROUP BY dense_id, outgoing_edge, incoming_edge)
+                   GROUP BY dense_id) sub
+                )
+            AS BIGINT),
+            src,
+            dst,
+            edge) as temp FROM (
+    select src, dst, any_value(edges) as edge FROM (
+        select src, dst, edges from edges_cte UNION all select dst, src, edges from edges_cte)
+    GROUP BY src, dst)
+) SELECT id, __x.temp + local_clustering_coefficient(0, a.rowid) as lcc
+        FROM (select count(cte1.temp) * 0 as temp from cte1) __x, Person a
+        ORDER BY id ASC;
+----
+14	0.33333334
+16	0.5
+32	0.8333333
+2199023255557	0.6666667
+2199023255573	1.0
+2199023255594	0.1904762
+4398046511139	0.0
+6597069766702	0.0
+8796093022234	0.0
+8796093022237	0.6666667
+8796093022244	0.0
+8796093022249	0.4
+10995116277761	0.3
+10995116277782	0.23809524
+10995116277783	0.0
+10995116277808	0.0
+13194139533342	1.0
+13194139533352	0.31111112
+13194139533355	0.2
+15393162788877	0.0
+17592186044443	0.0
+17592186044461	1.0
+19791209299968	1.0
+19791209299987	0.0
+21990232555526	0.0
+21990232555527	0.0
+24189255811081	0.125
+24189255811109	1.0
+26388279066632	0.0
+26388279066641	0.8333333
+26388279066655	0.33333334
+26388279066658	0.21794872
+26388279066668	0.5
+28587302322180	0.16666667
+28587302322191	0.0
+28587302322196	0.8333333
+28587302322204	0.2857143
+28587302322209	0.0
+28587302322223	0.0
+30786325577731	0.0
+30786325577740	1.0
+32985348833291	0.0
+32985348833318	0.0
+32985348833329	0.0
+35184372088834	0.0
+35184372088850	0.6666667
+35184372088856	0.33333334
+35184372088871	0.0
+37383395344394	0.0
+37383395344409	0.0
+
+query II
+WITH edges_cte AS (
+    SELECT a.rowid as src, c.rowid as dst, k.rowid as edges
+    FROM Person_knows_person k
+    JOIN Person a ON a.id = k.person1id
+    JOIN Person c ON c.id = k.person2id
+),
+cte1 AS (
+    SELECT CREATE_CSR_EDGE(
+            0,
+            (SELECT count(id) FROM Person),
+            CAST(
+                (SELECT sum(CREATE_CSR_VERTEX(
+                            0,
+                            (SELECT count(id) FROM Person),
+                            sub.dense_id,
+                            sub.cnt)
+                            ) * 2
+                FROM (
+                    SELECT dense_id, count(*) as cnt
+                    FROM (
+                        SELECT DISTINCT a.rowid AS dense_id, k.person1id AS outgoing_edge, k.person2id AS incoming_edge
+                        FROM Person a
+                        JOIN Person_knows_person k ON k.person1id = a.id
+                        UNION ALL
+                        SELECT DISTINCT a.rowid AS dense_id, k.person2id AS outgoing_edge, k.person1id AS incoming_edge
+                        FROM Person a
+                        JOIN Person_knows_person k ON k.person2id = a.id
+                    ) unique_edges
+                    GROUP BY dense_id -- group by dense_id to count the number of unique edges
+                ) sub
+            ) AS BIGINT),
+            src,
+            dst,
+            edge) as temp
+    FROM (
+        SELECT src, dst, any_value(edges) as edge
+        FROM (
+            SELECT src, dst, edges FROM edges_cte
+            UNION ALL
+            SELECT dst, src, edges FROM edges_cte
+        )
+        GROUP BY src, dst
+    )
+)
+SELECT id, __x.temp + local_clustering_coefficient(0, a.rowid) as lcc
+FROM (
+    SELECT count(cte1.temp) * 0 as temp FROM cte1
+) __x, Person a
+ORDER BY id ASC;
+----
+14	0.33333334
+16	0.5
+32	0.8333333
+2199023255557	0.6666667
+2199023255573	1.0
+2199023255594	0.1904762
+4398046511139	0.0
+6597069766702	0.0
+8796093022234	0.0
+8796093022237	0.6666667
+8796093022244	0.0
+8796093022249	0.4
+10995116277761	0.3
+10995116277782	0.23809524
+10995116277783	0.0
+10995116277808	0.0
+13194139533342	1.0
+13194139533352	0.31111112
+13194139533355	0.2
+15393162788877	0.0
+17592186044443	0.0
+17592186044461	1.0
+19791209299968	1.0
+19791209299987	0.0
+21990232555526	0.0
+21990232555527	0.0
+24189255811081	0.125
+24189255811109	1.0
+26388279066632	0.0
+26388279066641	0.8333333
+26388279066655	0.33333334
+26388279066658	0.21794872
+26388279066668	0.5
+28587302322180	0.16666667
+28587302322191	0.0
+28587302322196	0.8333333
+28587302322204	0.2857143
+28587302322209	0.0
+28587302322223	0.0
+30786325577731	0.0
+30786325577740	1.0
+32985348833291	0.0
+32985348833318	0.0
+32985348833329	0.0
+35184372088834	0.0
+35184372088850	0.6666667
+35184372088856	0.33333334
+35184372088871	0.0
+37383395344394	0.0
+37383395344409	0.0

--- a/test/sql/scalar/local_clustering_coefficient.test
+++ b/test/sql/scalar/local_clustering_coefficient.test
@@ -62,54 +62,14 @@ WITH cte1 AS (
         FROM (select count(cte1.temp) * 0 as temp from cte1) __x, Student a
         ORDER BY lcc DESC;
 ----
-0.5	Daniel
-0.5	Tavneet
-0.0	Gabor
-0.0	Peter
+1.0	Daniel
+1.0	Tavneet
+1.0	Gabor
+0.5	Peter
 0.0	David
 
-
-#statement ok
-#CREATE TABLE Node(id BIGINT);INSERT INTO Node VALUES (0), (1), (2), (3);
-#
-#statement ok
-#CREATE TABLE Edge(src BIGINT, dst BIGINT);INSERT INTO Edge VALUES (0,1), (0,2), (0,3), (1,0), (1,2), (1,3), (2,0), (2,1), (2,3), (3,0), (3,1), (3,2);
-
-#query III
-#WITH cte1 AS (
-#    SELECT  CREATE_CSR_EDGE(
-#            0,
-#            (SELECT count(a.id) FROM Edge a),
-#            CAST (
-#                (SELECT sum(CREATE_CSR_VERTEX(
-#                            0,
-#                            (SELECT count(a.id) FROM Node a),
-#                            sub.dense_id,
-#                            sub.cnt)
-#                            )
-#                FROM (
-#                    SELECT a.rowid as dense_id, count(k.src) as cnt
-#                    FROM Node a
-#                    LEFT JOIN Edge k ON k.src = a.id
-#                    GROUP BY a.rowid) sub
-#                )
-#            AS BIGINT),
-#            a.rowid,
-#            c.rowid,
-#            k.rowid) as temp
-#    FROM Edge k
-#    JOIN Node a on a.id = k.src
-#    JOIN Node c on c.id = k.dst
-#) SELECT __x.temp + local_clustering_coefficient(0, a.rowid) as lcc, a.name as a_name
-#        FROM (select count(cte1.temp) * 0 as temp from cte1) __x, Node a
-#----
-#[0, 0, 1]	Daniel	Tavneet
-#[0, 1, 2]	Daniel	Gabor
-#[0, 2, 3]	Daniel	Peter
-
-
 statement ok
-import database '~/git/duckpgq-experiments/data/SNB1-projected|';
+import database 'duckdb-pgq/data/SNB0.003';
 
 #query II
 #WITH neighbors AS (
@@ -237,83 +197,92 @@ query II
 WITH cte1 AS (
     SELECT  CREATE_CSR_EDGE(
             0,
-            (SELECT count(a.id) * 2 FROM Person a),
+            (SELECT count(a.id) FROM Person a),
             CAST (
                 (SELECT sum(CREATE_CSR_VERTEX(
                             0,
-                            (SELECT count(a.id) * 2 FROM Person a),
+                            (SELECT count(a.id) FROM Person a),
                             sub.dense_id,
                             sub.cnt)
-                            )
+                            ) * 2
                 FROM (
-                    SELECT a.rowid as dense_id, count(k.person1id) as cnt
-                    FROM Person a
-                    LEFT JOIN Person_knows_person k ON k.person1id = a.id
-                    GROUP BY a.rowid) sub
+                    SELECT dense_id, count(*) as cnt FROM (
+                        SELECT dense_id, outgoing_edge, incoming_edge
+                            FROM (
+                                SELECT a.rowid AS dense_id, k.person1id AS outgoing_edge, k.person2id AS incoming_edge
+                                FROM Person a
+                                JOIN Person_knows_person k ON k.person1id = a.id
+                                UNION ALL
+                                SELECT a.rowid AS dense_id, k.person2id AS outgoing_edge, k.person1id AS incoming_edge
+                                FROM Person a
+                                JOIN Person_knows_person k on k.person2id = a.id)
+                        GROUP BY dense_id, outgoing_edge, incoming_edge)
+                   GROUP BY dense_id) sub
                 )
             AS BIGINT),
             src,
             dst,
             edge) as temp FROM (
-    select src, dst, edge FROM (
+    select src, dst, any_value(edge) as edge FROM (
         select a.rowid as src, c.rowid as dst, k.rowid as edge FROM Person_knows_person k
         JOIN Person a on a.id = k.person1id
         JOIN Person c on c.id = k.person2id
         UNION ALL
         select a.rowid as src, c.rowid as dst, k.rowid as edge FROM Person_knows_person k
         JOIN Person a on a.id = k.person2id
-        JOIN Person c on c.id = k.person1id))
-) SELECT __x.temp + local_clustering_coefficient(0, a.rowid) as lcc, a.id as a_name
+        JOIN Person c on c.id = k.person1id)
+    GROUP BY src, dst)
+) SELECT id, __x.temp + local_clustering_coefficient(0, a.rowid) as lcc
         FROM (select count(cte1.temp) * 0 as temp from cte1) __x, Person a
-        ORDER BY lcc DESC;
+        ORDER BY id ASC;
 ----
-0.5	Arbaaz
-0.5	Lei
-0.5	Almira
-0.5	Alexei
-0.41666666	Miguel
-0.33333334	Eric
-0.25	Jan
-0.2	John
-0.2	Ken
-0.16666667	Hossein
-0.14285715	Celso
-0.102564104	Ali
-0.083333336	Evangelos
-0.06666667	Alim
-0.0	Ayesha
-0.0	Alejandro
-0.0	Rahul
-0.0	John
-0.0	John
-0.0	Adje van den Berg
-0.0	Joakim
-0.0	Rahul
-0.0	Mehmet
-0.0	Wojciech
-0.0	Ali
-0.0	John
-0.0	Jimmy
-0.0	Baby
-0.0	Jun
-0.0	Wei
-0.0	Djelaludin
-0.0	Otto
-0.0	Roberto
-0.0	Bryn
-0.0	Ge
-0.0	Yahya Ould Ahmed El
-0.0	Hans
-0.0	Ali
-0.0	Tissa
-0.0	Aleksandr
-0.0	Jose
-0.0	Cheng
-0.0	Alfonso
-0.0	Ashok
-0.0	Abdul Haris
-0.0	Neil
-0.0	Jie
-0.0	Alexei
-0.0	Wolfgang
-0.0	Luigi
+14	0.33333334
+16	0.5
+32	0.8333333
+2199023255557	0.6666667
+2199023255573	1.0
+2199023255594	0.1904762
+4398046511139	0.0
+6597069766702	0.0
+8796093022234	0.0
+8796093022237	0.6666667
+8796093022244	0.0
+8796093022249	0.4
+10995116277761	0.3
+10995116277782	0.23809524
+10995116277783	0.0
+10995116277808	0.0
+13194139533342	1.0
+13194139533352	0.31111112
+13194139533355	0.2
+15393162788877	0.0
+17592186044443	0.0
+17592186044461	1.0
+19791209299968	1.0
+19791209299987	0.0
+21990232555526	0.0
+21990232555527	0.0
+24189255811081	0.125
+24189255811109	1.0
+26388279066632	0.0
+26388279066641	0.8333333
+26388279066655	0.33333334
+26388279066658	0.21794872
+26388279066668	0.5
+28587302322180	0.16666667
+28587302322191	0.0
+28587302322196	0.8333333
+28587302322204	0.2857143
+28587302322209	0.0
+28587302322223	0.0
+30786325577731	0.0
+30786325577740	1.0
+32985348833291	0.0
+32985348833318	0.0
+32985348833329	0.0
+35184372088834	0.0
+35184372088850	0.6666667
+35184372088856	0.33333334
+35184372088871	0.0
+37383395344394	0.0
+37383395344409	0.0

--- a/test/sql/scalar/local_clustering_coefficient.test
+++ b/test/sql/scalar/local_clustering_coefficient.test
@@ -121,127 +121,70 @@ Invalid Error: foo is a vertex table, expected an edge table
 statement ok
 import database 'duckdb-pgq/data/SNB0.003';
 
-#query II
-#WITH neighbors AS (
-#    SELECT
-#        person1id AS id,
-#        person2id AS neighbor
-#    FROM
-#        person_knows_person
-#    UNION ALL
-#    SELECT
-#        person2id AS id,
-#        person1id AS neighbor
-#    FROM
-#        person_knows_person
-#),
-#in_degree AS (
-#    SELECT
-#        id,
-#        COUNT(DISTINCT neighbor) AS in_degree
-#    FROM
-#        neighbors
-#    GROUP BY
-#        id
-#),
-#out_degree AS (
-#    SELECT
-#        person1id AS id,
-#        COUNT(DISTINCT person2id) AS out_degree
-#    FROM
-#        person_knows_person
-#    GROUP BY
-#        person1id
-#),
-#triangles AS (
-#    SELECT
-#        pkp1.person1id AS id,
-#        COUNT(DISTINCT pkp2.person2id) AS triangle_count
-#    FROM
-#        person_knows_person pkp1
-#    JOIN
-#        person_knows_person pkp2 ON pkp1.person2id = pkp2.person1id
-#    JOIN
-#        person_knows_person pkp3 ON pkp2.person2id = pkp3.person2id AND pkp1.person1id = pkp3.person1id
-#    GROUP BY
-#        pkp1.person1id
-#),
-#local_clustering_coefficient AS (
-#    SELECT
-#        id,
-#        in_degree + out_degree AS degree,
-#        triangle_count,
-#        CASE
-#            WHEN (in_degree + out_degree) > 1 THEN 1.0 * triangle_count / ((in_degree + out_degree) * (in_degree + out_degree - 1))
-#            ELSE 0.0
-#        END AS local_clustering_coefficient
-#    FROM
-#        in_degree
-#    JOIN
-#        out_degree USING (id)
-#    LEFT JOIN
-#        triangles USING (id)
-#)
-#SELECT
-#    id,
-#    local_clustering_coefficient
-#FROM
-#    local_clustering_coefficient
-#ORDER BY
-#    local_clustering_coefficient DESC;
-#----
-#0.5	Arbaaz
-#0.5	Lei
-#0.5	Almira
-#0.5	Alexei
-#0.41666666	Miguel
-#0.33333334	Eric
-#0.25	Jan
-#0.2	John
-#0.2	Ken
-#0.16666667	Hossein
-#0.14285715	Celso
-#0.102564104	Ali
-#0.083333336	Evangelos
-#0.06666667	Alim
-#0.0	Ayesha
-#0.0	Alejandro
-#0.0	Rahul
-#0.0	John
-#0.0	John
-#0.0	Adje van den Berg
-#0.0	Joakim
-#0.0	Rahul
-#0.0	Mehmet
-#0.0	Wojciech
-#0.0	Ali
-#0.0	John
-#0.0	Jimmy
-#0.0	Baby
-#0.0	Jun
-#0.0	Wei
-#0.0	Djelaludin
-#0.0	Otto
-#0.0	Roberto
-#0.0	Bryn
-#0.0	Ge
-#0.0	Yahya Ould Ahmed El
-#0.0	Hans
-#0.0	Ali
-#0.0	Tissa
-#0.0	Aleksandr
-#0.0	Jose
-#0.0	Cheng
-#0.0	Alfonso
-#0.0	Ashok
-#0.0	Abdul Haris
-#0.0	Neil
-#0.0	Jie
-#0.0	Alexei
-#0.0	Wolfgang
-#0.0	Luigi
-#
-#
+statement ok
+-CREATE PROPERTY GRAPH snb
+VERTEX TABLES (
+    Person
+    )
+EDGE TABLES (
+    Person_knows_person     SOURCE KEY (Person1Id) REFERENCES Person (id)
+                            DESTINATION KEY (Person2Id) REFERENCES Person (id)
+                            LABEL Knows);
+
+query II
+select id, local_clustering_coefficient from local_clustering_coefficient(snb, person, knows);
+----
+14	0.33333334
+16	0.5
+32	0.8333333
+2199023255557	0.6666667
+2199023255573	1.0
+2199023255594	0.1904762
+4398046511139	0.0
+6597069766702	0.0
+8796093022234	0.0
+8796093022237	0.6666667
+8796093022244	0.0
+8796093022249	0.4
+10995116277761	0.3
+10995116277782	0.23809524
+10995116277783	0.0
+10995116277808	0.0
+13194139533342	1.0
+13194139533352	0.31111112
+13194139533355	0.2
+15393162788877	0.0
+17592186044443	0.0
+17592186044461	1.0
+19791209299968	1.0
+19791209299987	0.0
+21990232555526	0.0
+21990232555527	0.0
+24189255811081	0.125
+24189255811109	1.0
+26388279066632	0.0
+26388279066641	0.8333333
+26388279066655	0.33333334
+26388279066658	0.21794872
+26388279066668	0.5
+28587302322180	0.16666667
+28587302322191	0.0
+28587302322196	0.8333333
+28587302322204	0.2857143
+28587302322209	0.0
+28587302322223	0.0
+30786325577731	0.0
+30786325577740	1.0
+32985348833291	0.0
+32985348833318	0.0
+32985348833329	0.0
+35184372088834	0.0
+35184372088850	0.6666667
+35184372088856	0.33333334
+35184372088871	0.0
+37383395344394	0.0
+37383395344409	0.0
+
 
 query II
 WITH cte1 AS (

--- a/test/sql/scalar/local_clustering_coefficient.test
+++ b/test/sql/scalar/local_clustering_coefficient.test
@@ -19,8 +19,16 @@ EDGE TABLES (
             DESTINATION KEY ( dst ) REFERENCES Student ( id )
     );
 
-statement ok
+query II
 select * from local_clustering_coefficient(pg, student, know);
+----
+1.0	Daniel
+1.0	Tavneet
+1.0	Gabor
+0.5	Peter
+0.0	David
+
+
 
 query II
 WITH cte1 AS (

--- a/test/sql/scalar/local_clustering_coefficient.test
+++ b/test/sql/scalar/local_clustering_coefficient.test
@@ -80,6 +80,14 @@ select id, local_clustering_coefficient from local_clustering_coefficient(pg, st
 3	0.5
 4	0.0
 
+query III
+select a.id, a.name, local_clustering_coefficient from local_clustering_coefficient(pg, student, know), student a where a.id = lcc.id;
+----
+0	Daniel	1.0
+1	Tavneet	1.0
+2	Gabor	1.0
+3	Peter	0.5
+4	David	0.0
 
 statement ok
 import database 'duckdb-pgq/data/SNB0.003';

--- a/test/sql/scalar/local_clustering_coefficient.test
+++ b/test/sql/scalar/local_clustering_coefficient.test
@@ -72,13 +72,13 @@ WITH cte1 AS (
 0.0	David
 
 query II
-select * from local_clustering_coefficient(pg, student, know);
+select id, local_clustering_coefficient from local_clustering_coefficient(pg, student, know);
 ----
-1.0	Daniel
-1.0	Tavneet
-1.0	Gabor
-0.5	Peter
-0.0	David
+0	1.0
+1	1.0
+2	1.0
+3	0.5
+4	0.0
 
 
 statement ok

--- a/test/sql/scalar/local_clustering_coefficient.test
+++ b/test/sql/scalar/local_clustering_coefficient.test
@@ -32,10 +32,18 @@ WITH cte1 AS (
                             sub.cnt)
                             ) * 2
                 FROM (
-                    SELECT a.rowid as dense_id, count(k.src) * 2 as cnt
-                    FROM (SELECT a.rowid as dense_id FROM Student a
-                            LEFT JOIN Know k ON k.src = a.id
-                            GROUP BY a.rowid) sub
+                    SELECT dense_id, count(*) as cnt FROM (
+                        SELECT dense_id, outgoing_edge, incoming_edge
+                            FROM (
+                                SELECT a.rowid AS dense_id, k.src AS outgoing_edge, k.dst AS incoming_edge
+                                FROM Student a
+                                JOIN Know k ON k.src = a.id
+                                UNION ALL
+                                SELECT a.rowid AS dense_id, k.dst AS outgoing_edge, k.src AS incoming_edge
+                                FROM Student a
+                                JOIN know k on k.dst = a.id)
+                        GROUP BY dense_id, outgoing_edge, incoming_edge)
+                   GROUP BY dense_id) sub
                 )
             AS BIGINT),
             src,


### PR DESCRIPTION
Fixes #123 
Users can now calculate the local clustering coefficient using a table function `SELECT * FROM local_clustering_coefficient(<pg>, <vertex table>, <edge table>)`. 

The property graph must be registered. The vertex table must be the source table referenced by the edge table. 
Two columns are returned—the primary key column of the vertex table, and the column with the local clustering coefficient. 
The local clustering coefficient is calculated for every ID. 

The function only returns the correct result on undirected graphs. Since the edge table is always directed, we convert the edge table to be undirected in the CSR.

Joining this is a bit odd, a user has to write: `from local_clustering_coefficient(snb, person, knows), person where person.id = 37383395344409 and lcc.id = person.id;` for instance to only get the lcc of person `37383395344409`. Nothing can be done about this since the CSR has to be part of the query. 

Under the hood, this table function is converted using a BindReplace into a subquery. `select pk, local_clustering_coefficient(csr_id, src.rowid)` with a CTE to create the undirected CSR:

```sql
WITH edges_cte AS (
    SELECT a.rowid as src, c.rowid as dst, k.rowid as edges
    FROM Person_knows_person k
    JOIN Person a ON a.id = k.person1id
    JOIN Person c ON c.id = k.person2id
),
cte1 AS (
    SELECT CREATE_CSR_EDGE(
            0,
            (SELECT count(id) FROM Person),
            CAST(
                (SELECT sum(CREATE_CSR_VERTEX(
                            0,
                            (SELECT count(id) FROM Person),
                            sub.dense_id,
                            sub.cnt)
                            ) * 2
                FROM (
                    SELECT dense_id, count(*) as cnt
                    FROM (
                        SELECT DISTINCT a.rowid AS dense_id, k.person1id AS outgoing_edge, k.person2id AS incoming_edge
                        FROM Person a
                        JOIN Person_knows_person k ON k.person1id = a.id
                        UNION ALL
                        SELECT DISTINCT a.rowid AS dense_id, k.person2id AS outgoing_edge, k.person1id AS incoming_edge
                        FROM Person a
                        JOIN Person_knows_person k ON k.person2id = a.id
                    ) unique_edges
                    GROUP BY dense_id -- group by dense_id to count the number of unique edges
                ) sub
            ) AS BIGINT),
            src,
            dst,
            edge) as temp
    FROM (
        SELECT src, dst, any_value(edges) as edge
        FROM (
            SELECT src, dst, edges FROM edges_cte
            UNION ALL
            SELECT dst, src, edges FROM edges_cte
        )
        GROUP BY src, dst
    )
)
SELECT id, __x.temp + local_clustering_coefficient(0, a.rowid) as lcc
FROM (
    SELECT count(cte1.temp) * 0 as temp FROM cte1
) __x, Person a
ORDER BY id ASC;
```
 