### PR TITLE
Support path-finding on undirected edges

### DIFF
--- a/src/core/functions/table/match.cpp
+++ b/src/core/functions/table/match.cpp
@@ -486,8 +486,15 @@ unique_ptr<ParsedExpression> PGQMatchFunction::CreatePathFindingFunction(
         }
         if (final_select_node->cte_map.map.find("cte1") == final_select_node->cte_map.map.end()) {
           edge_element = reinterpret_cast<PathElement *>(edge_subpath->path_list[0].get());
-          final_select_node->cte_map.map["cte1"] =
+          if (edge_element->match_type == PGQMatchType::MATCH_EDGE_RIGHT) {
+            final_select_node->cte_map.map["cte1"] =
             CreateDirectedCSRCTE(FindGraphTable(edge_element->label, pg_table), previous_vertex_element->variable_binding, edge_element->variable_binding, next_vertex_element->variable_binding);
+          } else if (edge_element->match_type == PGQMatchType::MATCH_EDGE_ANY) {
+            final_select_node->cte_map.map["cte1"] =
+              CreateUndirectedCSRCTE(FindGraphTable(edge_element->label, pg_table), final_select_node);
+          } else {
+            throw NotImplementedException("Cannot do shortest path for edge type %s", edge_element->match_type == PGQMatchType::MATCH_EDGE_LEFT ? "MATCH_EDGE_LEFT" : "MATCH_EDGE_LEFT_RIGHT");
+          }
         }
         string shortest_path_cte_name = "shortest_path_cte" ;
         if (final_select_node->cte_map.map.find(shortest_path_cte_name) == final_select_node->cte_map.map.end()) {

--- a/src/core/functions/table/match.cpp
+++ b/src/core/functions/table/match.cpp
@@ -659,12 +659,23 @@ void PGQMatchFunction::AddPathFinding(
     const string &prev_binding, const string &edge_binding,
     const string &next_binding,
     const shared_ptr<PropertyGraphTable> &edge_table,
-    CreatePropertyGraphInfo &pg_table, SubPath *subpath) {
+    CreatePropertyGraphInfo &pg_table, SubPath *subpath,
+    PGQMatchType edge_type) {
   //! START
   //! FROM (SELECT count(cte1.temp) * 0 as temp from cte1) __x
   if (select_node->cte_map.map.find("cte1") == select_node->cte_map.map.end()) {
+    if (edge_type == PGQMatchType::MATCH_EDGE_RIGHT) {
       select_node->cte_map.map["cte1"] =
       CreateDirectedCSRCTE(edge_table, prev_binding, edge_binding, next_binding);
+    } else if (edge_type == PGQMatchType::MATCH_EDGE_ANY) {
+      select_node->cte_map.map["cte1"] =
+          CreateUndirectedCSRCTE(edge_table, select_node);
+    } else {
+      throw NotImplementedException("Cannot do shortest path for edge type %s",
+                                    edge_type == PGQMatchType::MATCH_EDGE_LEFT
+                                        ? "MATCH_EDGE_LEFT"
+                                        : "MATCH_EDGE_LEFT_RIGHT");
+    }
   }
   if (select_node->cte_map.map.find("shortest_path_cte") != select_node->cte_map.map.end()) {
     return;
@@ -860,9 +871,9 @@ void PGQMatchFunction::ProcessPathList(
         // Add the path-finding
         AddPathFinding(final_select_node, conditions,
         previous_vertex_element->variable_binding,
-        edge_element->variable_binding,
-        next_vertex_element->variable_binding, edge_table,
-        pg_table, edge_subpath);
+                       edge_element->variable_binding,
+                       next_vertex_element->variable_binding, edge_table,
+        pg_table, edge_subpath, edge_element->match_type);
     } else {
       AddEdgeJoins(edge_table, previous_vertex_table, next_vertex_table,
                    edge_element->match_type, edge_element->variable_binding,

--- a/src/core/utils/compressed_sparse_row.cpp
+++ b/src/core/utils/compressed_sparse_row.cpp
@@ -377,9 +377,74 @@ unique_ptr<SelectNode> CreateOuterSelectNode(unique_ptr<FunctionExpression> crea
   return outer_select_node;
 }
 
+// Function to create the CTE for the edges
+unique_ptr<CommonTableExpressionInfo> MakeEdgesCTE(const shared_ptr<PropertyGraphTable> &edge_pg_entry) {
+    std::vector<unique_ptr<ParsedExpression>> select_expression;
+    auto src_col_ref = make_uniq<ColumnRefExpression>("rowid", "src_table");
+    src_col_ref->alias = "src";
+
+    select_expression.emplace_back(std::move(src_col_ref));
+
+    auto dst_col_ref = make_uniq<ColumnRefExpression>("rowid", "dst_table");
+    dst_col_ref->alias = "dst";
+    select_expression.emplace_back(std::move(dst_col_ref));
+
+    auto edge_col_ref = make_uniq<ColumnRefExpression>("rowid", edge_pg_entry->table_name);
+    edge_col_ref->alias = "edges";
+    select_expression.emplace_back(std::move(edge_col_ref));
+
+    auto select_node = make_uniq<SelectNode>();
+    select_node->select_list = std::move(select_expression);
+
+    auto edge_table_ref = make_uniq<BaseTableRef>();
+    edge_table_ref->table_name = edge_pg_entry->table_name;
+
+    auto src_table_ref = make_uniq<BaseTableRef>();
+    src_table_ref->table_name = edge_pg_entry->source_reference;
+    src_table_ref->alias = "src_table";
+
+    auto join_ref = make_uniq<JoinRef>(JoinRefType::REGULAR);
+
+    auto first_join_ref = make_uniq<JoinRef>(JoinRefType::REGULAR);
+    first_join_ref->type = JoinType::INNER;
+    first_join_ref->left = std::move(edge_table_ref);
+    first_join_ref->right = std::move(src_table_ref);
+
+    auto edge_from_ref = make_uniq<ColumnRefExpression>(edge_pg_entry->source_fk[0], edge_pg_entry->table_name);
+    auto src_cid_ref = make_uniq<ColumnRefExpression>(edge_pg_entry->source_pk[0], "src_table");
+    first_join_ref->condition = make_uniq<ComparisonExpression>(ExpressionType::COMPARE_EQUAL, std::move(edge_from_ref), std::move(src_cid_ref));
+
+    auto dst_table_ref = make_uniq<BaseTableRef>();
+    dst_table_ref->table_name = edge_pg_entry->destination_reference;
+    dst_table_ref->alias = "dst_table";
+
+    auto second_join_ref = make_uniq<JoinRef>(JoinRefType::REGULAR);
+    second_join_ref->type = JoinType::INNER;
+    second_join_ref->left = std::move(first_join_ref);
+    second_join_ref->right = std::move(dst_table_ref);
+
+    auto edge_to_ref = make_uniq<ColumnRefExpression>(edge_pg_entry->destination_fk[0], edge_pg_entry->table_name);
+    auto dst_cid_ref = make_uniq<ColumnRefExpression>(edge_pg_entry->destination_pk[0], "dst_table");
+    second_join_ref->condition = make_uniq<ComparisonExpression>(ExpressionType::COMPARE_EQUAL, std::move(edge_to_ref), std::move(dst_cid_ref));
+
+    select_node->from_table = std::move(second_join_ref);
+
+    auto select_statement = make_uniq<SelectStatement>();
+    select_statement->node = std::move(select_node);
+
+    auto result = make_uniq<CommonTableExpressionInfo>();
+    result->query = std::move(select_statement);
+    return result;
+}
+
 
 // Function to create the CTE for the Undirected CSR
-unique_ptr<CommonTableExpressionInfo> CreateUndirectedCSRCTE(const shared_ptr<PropertyGraphTable> &edge_table) {
+unique_ptr<CommonTableExpressionInfo> CreateUndirectedCSRCTE(const shared_ptr<PropertyGraphTable> &edge_table,
+                       const unique_ptr<SelectNode> &select_node) {
+  if (select_node->cte_map.map.find("edges_cte") == select_node->cte_map.map.end()) {
+    select_node->cte_map.map["edges_cte"] = MakeEdgesCTE(edge_table);
+  }
+
   auto csr_edge_id_constant = make_uniq<ConstantExpression>(Value::INTEGER(0));
   auto count_create_edge_select = GetCountTable(edge_table, edge_table->source_reference);
 

--- a/src/core/utils/duckpgq_bitmap.cpp
+++ b/src/core/utils/duckpgq_bitmap.cpp
@@ -4,7 +4,7 @@ namespace duckpgq {
 
 namespace core {
 
-DuckPGQBitmap::DuckPGQBitmap(size_t size) : size(size) {
+DuckPGQBitmap::DuckPGQBitmap(size_t size) {
   bitmap.resize((size + 63) / 64, 0);
 }
 

--- a/src/include/duckpgq/core/functions/table/match.hpp
+++ b/src/include/duckpgq/core/functions/table/match.hpp
@@ -130,7 +130,7 @@ public:
     const string &prev_binding, const string &edge_binding,
     const string &next_binding,
     const shared_ptr<PropertyGraphTable> &edge_table,
-    CreatePropertyGraphInfo &pg_table, SubPath *subpath);
+    CreatePropertyGraphInfo &pg_table, SubPath *subpath, PGQMatchType edge_type);
 
   static void
   AddEdgeJoins(const shared_ptr<PropertyGraphTable> &edge_table,

--- a/src/include/duckpgq/core/utils/compressed_sparse_row.hpp
+++ b/src/include/duckpgq/core/utils/compressed_sparse_row.hpp
@@ -66,10 +66,12 @@ struct CSRFunctionData : FunctionData {
 };
 
 // CSR BindReplace functions
-unique_ptr<CommonTableExpressionInfo> CreateUndirectedCSRCTE(const shared_ptr<PropertyGraphTable> &edge_table);
+unique_ptr<CommonTableExpressionInfo> CreateUndirectedCSRCTE(const shared_ptr<PropertyGraphTable> &edge_table,
+                       const unique_ptr<SelectNode> &select_node);
 unique_ptr<CommonTableExpressionInfo> CreateDirectedCSRCTE(const shared_ptr<PropertyGraphTable> &edge_table, const string &prev_binding, const string &edge_binding, const string &next_binding);
 
 // Helper functions
+unique_ptr<CommonTableExpressionInfo> MakeEdgesCTE(const shared_ptr<PropertyGraphTable> &edge_pg_entry);
 unique_ptr<SubqueryExpression> CreateDirectedCSRVertexSubquery(const shared_ptr<PropertyGraphTable> &edge_table, const std::string &binding);
 unique_ptr<SubqueryExpression> CreateUndirectedCSRVertexSubquery(const shared_ptr<PropertyGraphTable> &edge_table, const std::string &binding);
 unique_ptr<SelectNode> CreateOuterSelectEdgesNode();

--- a/src/include/duckpgq/core/utils/duckpgq_bitmap.hpp
+++ b/src/include/duckpgq/core/utils/duckpgq_bitmap.hpp
@@ -1,7 +1,7 @@
 //===----------------------------------------------------------------------===//
 //                         DuckPGQ
 //
-// duckpgq/utils/duckpgq_bitmap.hpp
+// duckpgq/core/utils/duckpgq_bitmap.hpp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -22,7 +22,6 @@ public:
 
 private:
   vector<uint64_t> bitmap;
-  size_t size;
 };
 
 } // namespace core

--- a/test/sql/path_finding/subpath_match.test
+++ b/test/sql/path_finding/subpath_match.test
@@ -1,5 +1,5 @@
 # name: test/sql/sqlpgq/subpath_match.test
-# group: [sqlpgq]
+# group: [duckpgq]
 
 #statement ok
 #pragma enable_verification

--- a/test/sql/path_finding/undirected_paths.test
+++ b/test/sql/path_finding/undirected_paths.test
@@ -46,3 +46,110 @@ query III
 4	2	1
 4	3	1
 4	4	0
+
+statement error
+-FROM GRAPH_TABLE (pg
+    MATCH
+    o = ANY SHORTEST (a:Student WHERE a.id = 4)<-[e:know]- *(b:Student)
+    COLUMNS (a.id as a_id, b.id as b_id, path_length(o))
+    ) study
+    ORDER BY a_id, b_id;
+----
+Cannot do shortest path for edge type MATCH_EDGE_LEFT
+
+statement error
+-FROM GRAPH_TABLE (pg
+    MATCH
+    o = ANY SHORTEST (a:Student WHERE a.id = 4)<-[e:know]-> *(b:Student)
+    COLUMNS (a.id as a_id, b.id as b_id, path_length(o))
+    ) study
+    ORDER BY a_id, b_id;
+----
+Cannot do shortest path for edge type MATCH_EDGE_LEFT_RIGHT
+
+query II
+-FROM GRAPH_TABLE (pg
+    MATCH
+    (a:Student WHERE a.id = 4)-[e:know]-{0,1}(b:Student)
+    COLUMNS (a.id as a_id, b.id as b_id, path_length(o))
+    ) study
+    ORDER BY a_id, b_id;
+----
+4	2
+4	3
+
+query III
+-FROM GRAPH_TABLE (pg
+    MATCH
+    o = ANY SHORTEST (a:Student WHERE a.id = 999)-[e:know]- *(b:Student)
+    COLUMNS (a.id as a_id, b.id as b_id, path_length(o))
+    ) study
+    ORDER BY a_id, b_id;
+----
+
+query III
+-FROM GRAPH_TABLE (pg
+    MATCH
+    o = ANY SHORTEST (a:Student)-[e:know]- *(b:Student)
+    COLUMNS (a.id as a_id, b.id as b_id, path_length(o))
+    ) study
+    ORDER BY a_id, b_id;
+----
+0	0	0
+0	1	1
+0	2	1
+0	3	1
+0	4	2
+1	0	1
+1	1	0
+1	2	1
+1	3	1
+1	4	2
+2	0	1
+2	1	1
+2	2	0
+2	3	1
+2	4	1
+3	0	1
+3	1	1
+3	2	1
+3	3	0
+3	4	1
+4	0	2
+4	1	2
+4	2	1
+4	3	1
+4	4	0
+
+query III
+-FROM GRAPH_TABLE (pg
+    MATCH
+    o = ANY SHORTEST (a:Student WHERE a.id = 3)-[e:know]- *(b:Student WHERE b.id = 3)
+    COLUMNS (a.id as a_id, b.id as b_id, path_length(o))
+    ) study
+    ORDER BY a_id, b_id;
+----
+3	3	0
+
+query III
+-FROM GRAPH_TABLE (pg
+    MATCH
+    o = ANY SHORTEST (a:Student WHERE a.id = 0)-[e:know]- *(b:Student WHERE b.id = 5)
+    COLUMNS (a.id as a_id, b.id as b_id, path_length(o))
+    ) study
+    ORDER BY a_id, b_id;
+----
+
+query III
+-FROM GRAPH_TABLE (pg
+    MATCH
+    o = ANY SHORTEST (a:Student WHERE a.id = 0)-[e:know]-{0,2}(b:Student)
+    COLUMNS (a.id as a_id, b.id as b_id, path_length(o))
+    ) study
+    ORDER BY a_id, b_id;
+----
+0	0	0
+0	1	1
+0	2	1
+0	3	1
+0	4	2

--- a/test/sql/path_finding/undirected_paths.test
+++ b/test/sql/path_finding/undirected_paths.test
@@ -1,0 +1,32 @@
+# name: test/sql/path_finding/undirected_paths.test
+# group: [duckpgq]
+
+require duckpgq
+
+statement ok
+CREATE TABLE Student(id BIGINT, name VARCHAR);INSERT INTO Student VALUES (0, 'Daniel'), (1, 'Tavneet'), (2, 'Gabor'), (3, 'Peter'), (4, 'David');
+
+statement ok
+CREATE TABLE know(src BIGINT, dst BIGINT, id BIGINT);INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (3,0, 13), (1,2, 14), (1,3, 15), (2,3, 16), (4,3, 17), (2, 4, 18);
+
+statement ok
+-CREATE PROPERTY GRAPH pg
+VERTEX TABLES (
+    Student
+    )
+EDGE TABLES (
+    know   SOURCE KEY (src) REFERENCES Student (id)
+                DESTINATION KEY (dst) REFERENCES Student (id)
+    );
+
+query III
+-FROM GRAPH_TABLE (pg
+    MATCH
+    o = ANY SHORTEST (a:Student WHERE a.id = 0)-[e:know]- *(b:Student)
+    COLUMNS (a.id as a_id, b.id as b_id, path_length(o))
+    ) study
+----
+0	1	1
+0	2	1
+0	3	1
+0	4	2

--- a/test/sql/path_finding/undirected_paths.test
+++ b/test/sql/path_finding/undirected_paths.test
@@ -25,8 +25,24 @@ query III
     o = ANY SHORTEST (a:Student WHERE a.id = 0)-[e:know]- *(b:Student)
     COLUMNS (a.id as a_id, b.id as b_id, path_length(o))
     ) study
+    ORDER BY a_id, b_id;
 ----
+0	0	0
 0	1	1
 0	2	1
 0	3	1
 0	4	2
+
+query III
+-FROM GRAPH_TABLE (pg
+    MATCH
+    o = ANY SHORTEST (a:Student WHERE a.id = 4)-[e:know]- *(b:Student)
+    COLUMNS (a.id as a_id, b.id as b_id, path_length(o))
+    ) study
+    ORDER BY a_id, b_id;
+----
+4	0	2
+4	1	2
+4	2	1
+4	3	1
+4	4	0


### PR DESCRIPTION
Fixes #87 

This PR adds support for path-finding on undirected edges. Building an undirected CSR and then performing MS-BFS over this CSR. It can be done both inside named subpaths and outside. 

Example query:
```sql
CREATE TABLE Student(id BIGINT, name VARCHAR);INSERT INTO Student VALUES (0, 'Daniel'), (1, 'Tavneet'), (2, 'Gabor'), (3, 'Peter'), (4, 'David');
CREATE TABLE know(src BIGINT, dst BIGINT, id BIGINT);INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (3,0, 13), (1,2, 14), (1,3, 15), (2,3, 16), (4,3, 17), (2, 4, 18);
```

```sql
FROM GRAPH_TABLE (pg
    MATCH
    o = ANY SHORTEST (a:Student WHERE a.id = 0)-[e:know]-{0,2}(b:Student)
    COLUMNS (a.id as a_id, b.id as b_id, path_length(o))
    )
    ORDER BY a_id, b_id;
```