### PR TITLE
Implicitly defined source and destination keys

### DIFF
--- a/src/core/functions/table/create_property_graph.cpp
+++ b/src/core/functions/table/create_property_graph.cpp
@@ -216,8 +216,8 @@ unique_ptr<FunctionData> CreatePropertyGraphFunction::CreatePropertyGraphBind(
         v_table_names.end()) {
       throw Exception(ExceptionType::INVALID, "Referenced vertex table " +
                                                   edge_table->source_reference +
-                                                  " does not exist.");
-        }
+                                                  " is not registered in the vertex tables.");
+    }
 
     auto &pk_source_table = catalog.GetEntry<TableCatalogEntry>(
         context, info->schema, edge_table->source_reference);
@@ -229,12 +229,12 @@ unique_ptr<FunctionData> CreatePropertyGraphFunction::CreatePropertyGraphBind(
       }
     }
 
-    if (v_table_names.find(edge_table->source_reference) ==
+    if (v_table_names.find(edge_table->destination_reference) ==
         v_table_names.end()) {
       throw Exception(ExceptionType::INVALID, "Referenced vertex table " +
-                                                  edge_table->source_reference +
-                                                  " does not exist");
-        }
+                                                  edge_table->destination_reference +
+                                                  " is not registered in the vertex tables");
+    }
 
     auto &pk_destination_table = catalog.GetEntry<TableCatalogEntry>(
         context, info->schema, edge_table->destination_reference);

--- a/src/core/functions/table/create_property_graph.cpp
+++ b/src/core/functions/table/create_property_graph.cpp
@@ -121,8 +121,6 @@ unique_ptr<FunctionData> CreatePropertyGraphFunction::CreatePropertyGraphBind(
       CheckPropertyGraphTableLabels(edge_table, table);
       auto &table_constraints = table.GetConstraints();
 
-      // TODO what if either one is empty? --> should not be allowed in the
-      // parser but add a test for it
       if (edge_table->source_fk.empty() && edge_table->source_pk.empty()) {
         if (table_constraints.empty()) {
           throw Exception(ExceptionType::INVALID,

--- a/src/core/functions/table/create_property_graph.cpp
+++ b/src/core/functions/table/create_property_graph.cpp
@@ -138,7 +138,7 @@ unique_ptr<FunctionData> CreatePropertyGraphFunction::CreatePropertyGraphBind(
             // If we get here again, it means that a primary key - foreign key relationship was found earlier with the same table. Leads to ambiguity. Throw an exception.
             if (!edge_table->source_pk.empty() && !edge_table->source_fk.empty()) {
               throw Exception(ExceptionType::INVALID, "Multiple primary key - foreign key relationships detected with the same table. "
-                                        "Please explicitly define the primary key and foreign key columns using SOURCE KEY <primary key> references " + edge_table->source_reference + " <foreign key>");
+                                        "Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> references " + edge_table->source_reference + " <foreign key>`");
             }
             edge_table->source_pk = fk_constraint.pk_columns;
             edge_table->source_fk = fk_constraint.fk_columns;

--- a/src/core/functions/table/create_property_graph.cpp
+++ b/src/core/functions/table/create_property_graph.cpp
@@ -75,7 +75,7 @@ void CreatePropertyGraphFunction::ValidateKeys(shared_ptr<PropertyGraphTable> &e
     if (table_constraints.empty()) {
       throw Exception(ExceptionType::INVALID,
                       "No primary key - foreign key relationship found in " +
-                          edge_table->table_name + " with " + key_type +
+                          edge_table->table_name + " with " + StringUtil::Upper(key_type) +
                           " table " + reference);
     }
 
@@ -89,9 +89,9 @@ void CreatePropertyGraphFunction::ValidateKeys(shared_ptr<PropertyGraphTable> &e
         if (!pk_columns.empty() && !fk_columns.empty()) {
           throw Exception(
               ExceptionType::INVALID,
-              "Multiple primary key - foreign key relationships detected with the same table. "
+              "Multiple primary key - foreign key relationships detected between " + edge_table->table_name + " and " + reference + ". "
               "Please explicitly define the primary key and foreign key columns using `" +
-                  key_type + " KEY <primary key> REFERENCES " + reference + " <foreign key>`");
+                  StringUtil::Upper(key_type) + " KEY <primary key> REFERENCES " + reference + " <foreign key>`");
         }
         pk_columns = fk_constraint.pk_columns;
         fk_columns = fk_constraint.fk_columns;
@@ -100,13 +100,13 @@ void CreatePropertyGraphFunction::ValidateKeys(shared_ptr<PropertyGraphTable> &e
 
     if (pk_columns.empty()) {
       throw Exception(ExceptionType::INVALID,
-                      "The primary key for the " + key_type + " table " + reference +
+                      "The primary key for the " + StringUtil::Upper(key_type) + " table " + reference +
                           " is not defined in the edge table " + edge_table->table_name);
     }
 
     if (fk_columns.empty()) {
       throw Exception(ExceptionType::INVALID,
-                      "The foreign key for the " + key_type + " table " + reference +
+                      "The foreign key for the " + StringUtil::Upper(key_type) + " table " + reference +
                           " is not defined in the edge table " + edge_table->table_name);
     }
   }

--- a/src/core/functions/table/create_property_graph.cpp
+++ b/src/core/functions/table/create_property_graph.cpp
@@ -166,6 +166,12 @@ unique_ptr<FunctionData> CreatePropertyGraphFunction::CreatePropertyGraphBind(
                               edge_table->table_name);
         }
       }
+    if (edge_table->destination_fk.empty() && edge_table->destination_pk.empty()) {
+      if (table_constraints.empty()) {
+        throw Exception(ExceptionType::INVALID, "No primary key - foreign key relationship found in " +
+                                  edge_table->table_name + " with destination table " +
+                                  edge_table->destination_reference);
+      }
       for (const auto &constraint : table_constraints) {
         if (constraint->type == ConstraintType::FOREIGN_KEY) {
           auto fk_constraint = constraint->Cast<ForeignKeyConstraint>();
@@ -184,7 +190,7 @@ unique_ptr<FunctionData> CreatePropertyGraphFunction::CreatePropertyGraphBind(
                 "Please explicitly define the primary key and foreign key "
                 "columns using `DESTINATION KEY <primary key> references " +
                     edge_table->destination_reference + " <foreign key>`");
-          }
+              }
           edge_table->destination_pk = fk_constraint.pk_columns;
           edge_table->destination_fk = fk_constraint.fk_columns;
         }
@@ -211,6 +217,7 @@ unique_ptr<FunctionData> CreatePropertyGraphFunction::CreatePropertyGraphBind(
                               edge_table->table_name);
         }
       }
+    }
 
     if (v_table_names.find(edge_table->source_reference) ==
         v_table_names.end()) {

--- a/src/include/duckpgq/core/functions/table/create_property_graph.hpp
+++ b/src/include/duckpgq/core/functions/table/create_property_graph.hpp
@@ -48,7 +48,21 @@ public:
                           vector<LogicalType> &return_types,
                           vector<string> &names);
 
-  static unique_ptr<GlobalTableFunctionState>
+  static void ValidateVertexTableRegistration(const string &reference, const case_insensitive_set_t &v_table_names);
+
+  static void ValidatePrimaryKeyInTable(Catalog &catalog, ClientContext &context, const string &schema,
+                               const string &reference, const vector<string> &pk_columns);
+
+  static void ValidateKeys(shared_ptr<PropertyGraphTable> &edge_table,
+                    const string &reference, const string &key_type,
+                    vector<string> &pk_columns, vector<string> &fk_columns,
+                    const vector<unique_ptr<Constraint>> &table_constraints);
+
+  static void ValidateForeignKeyColumns(shared_ptr<PropertyGraphTable> &edge_table,
+                                 const vector<string> &fk_columns,
+                                 optional_ptr<TableCatalogEntry> &table)
+
+      static unique_ptr<GlobalTableFunctionState>
   CreatePropertyGraphInit(ClientContext &context,
                           TableFunctionInitInput &input);
 

--- a/src/include/duckpgq/core/functions/table/create_property_graph.hpp
+++ b/src/include/duckpgq/core/functions/table/create_property_graph.hpp
@@ -60,7 +60,7 @@ public:
 
   static void ValidateForeignKeyColumns(shared_ptr<PropertyGraphTable> &edge_table,
                                  const vector<string> &fk_columns,
-                                 optional_ptr<TableCatalogEntry> &table)
+                                 optional_ptr<TableCatalogEntry> &table);
 
       static unique_ptr<GlobalTableFunctionState>
   CreatePropertyGraphInit(ClientContext &context,

--- a/test/sql/create_pg/create_pg_with_pk_fk.test
+++ b/test/sql/create_pg/create_pg_with_pk_fk.test
@@ -156,5 +156,135 @@ EDGE TABLES (n SOURCE m DESTINATION m);
 ----
 Invalid Error: The primary key for the source table m is not defined in the edge table n
 
+statement error
+-CREATE PROPERTY GRAPH g4
+VERTEX TABLES (m)
+EDGE TABLES (n SOURCE KEY (src) REFERENCES m DESTINATION m);
+----
+Parser Error: syntax error at or near "DESTINATION"
 
+statement ok
+CREATE TABLE p (
+    id BIGINT PRIMARY KEY,
+    name VARCHAR
+);
 
+statement ok
+CREATE TABLE q (
+    id BIGINT PRIMARY KEY,
+    src BIGINT,
+    dst BIGINT REFERENCES p(id)
+);
+
+statement error
+CREATE PROPERTY GRAPH g5
+VERTEX TABLES (p)
+EDGE TABLES (q DESTINATION p);
+----
+Parser Error: syntax error at or near "DESTINATION"
+
+statement ok
+CREATE TABLE u (
+    id BIGINT PRIMARY KEY,
+    name VARCHAR
+);
+
+statement ok
+CREATE TABLE v2 (
+    id BIGINT PRIMARY KEY,
+    src BIGINT REFERENCES u(id),
+    dst BIGINT
+);
+
+statement ok
+CREATE TABLE w2 (
+    id BIGINT PRIMARY KEY,
+    src BIGINT,
+    dst BIGINT REFERENCES u(id)
+);
+
+statement error
+CREATE PROPERTY GRAPH g6
+VERTEX TABLES (u)
+EDGE TABLES (v2 SOURCE u, w2 DESTINATION u);
+----
+Parser Error: syntax error at or near ","
+
+statement ok
+CREATE TABLE vertex_b (
+    id BIGINT PRIMARY KEY,
+    name VARCHAR
+);
+
+statement ok
+-CREATE PROPERTY GRAPH g11
+VERTEX TABLES (vertex_b);
+
+statement ok
+CREATE TABLE node_a (
+    id BIGINT PRIMARY KEY,
+    name VARCHAR
+);
+
+statement ok
+CREATE TABLE edge_a (
+    src BIGINT REFERENCES node_a(id),
+    dst BIGINT REFERENCES node_a(id)
+);
+
+statement error
+-CREATE PROPERTY GRAPH g10
+VERTEX TABLES (node_a)
+EDGE TABLES (edge_a);
+----
+Parser Error: syntax error at or near ")"
+
+statement error
+-CREATE PROPERTY GRAPH g10
+VERTEX TABLES (node_a)
+EDGE TABLES (edge_a SOURCE node_a DESTINATION KEY (dst) REFERENCES node_a (id));
+----
+Invalid Error: Multiple primary key - foreign key relationships detected with the same table. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> references node_a <foreign key>`
+
+statement ok
+-CREATE PROPERTY GRAPH g10
+VERTEX TABLES (node_a)
+EDGE TABLES (edge_a SOURCE KEY (src) REFERENCES node_a (id) DESTINATION KEY (dst) REFERENCES node_a (id));
+
+statement ok
+CREATE OR REPLACE TABLE a (
+    id BIGINT PRIMARY KEY,
+    name VARCHAR
+);
+
+statement ok
+CREATE OR REPLACE TABLE b (
+    id BIGINT PRIMARY KEY,
+    description VARCHAR
+);
+
+statement ok
+CREATE TABLE edge_ab (
+    id BIGINT PRIMARY KEY,
+    src BIGINT REFERENCES a(id),
+    dst BIGINT REFERENCES b(id)
+);
+
+statement ok
+-CREATE PROPERTY GRAPH g_relationship
+VERTEX TABLES (a, b)
+EDGE TABLES (edge_ab SOURCE a DESTINATION b);
+
+statement ok
+INSERT INTO a VALUES (1, 'Vertex A');
+
+statement ok
+INSERT INTO b VALUES (2, 'Vertex B');
+
+statement ok
+INSERT INTO edge_ab VALUES (1, 1, 2);
+
+query II
+-FROM GRAPH_TABLE (g_relationship MATCH (a:a)-[edge_ab:edge_ab]->(b:b) COLUMNS (a.id, b.id));
+----
+1	2

--- a/test/sql/create_pg/create_pg_with_pk_fk.test
+++ b/test/sql/create_pg/create_pg_with_pk_fk.test
@@ -105,3 +105,55 @@ CREATE TABLE b_pk (
 
 statement ok
 -CREATE PROPERTY GRAPH g2 VERTEX TABLES (a_pk) EDGE TABLES (b_pk SOURCE a_pk DESTINATION a_pk);
+
+statement ok
+CREATE TABLE x (
+    id BIGINT PRIMARY KEY,
+    name VARCHAR
+);
+
+statement ok
+CREATE TABLE y (
+    id BIGINT PRIMARY KEY,
+    src BIGINT REFERENCES x(id),
+    dst BIGINT REFERENCES x(id)
+);
+
+statement error
+-CREATE PROPERTY GRAPH g3
+VERTEX TABLES (x)
+EDGE TABLES (y SOURCE x DESTINATION x);
+----
+Invalid Error: Multiple primary key - foreign key relationships detected with the same table. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> references x <foreign key>`
+
+statement ok
+CREATE PROPERTY GRAPH g3_explicit
+VERTEX TABLES (x)
+EDGE TABLES (y SOURCE KEY src REFERENCES x(id) DESTINATION KEY dst REFERENCES x(id));
+
+query II
+-FROM GRAPH_TABLE (g3_explicit MATCH (x:x)-[y:y]->(x:x) COLUMNS (x.id));
+----
+
+statement ok
+CREATE TABLE m (
+    id BIGINT PRIMARY KEY,
+    name VARCHAR
+);
+
+statement ok
+CREATE TABLE n (
+    id BIGINT PRIMARY KEY,
+    src BIGINT,
+    dst BIGINT
+);
+
+statement error
+-CREATE PROPERTY GRAPH g4
+VERTEX TABLES (m)
+EDGE TABLES (n SOURCE m DESTINATION m);
+----
+Invalid Error: No primary key - foreign key relationship found in n with source table m
+
+
+

--- a/test/sql/create_pg/create_pg_with_pk_fk.test
+++ b/test/sql/create_pg/create_pg_with_pk_fk.test
@@ -62,3 +62,46 @@ query II
 -FROM GRAPH_TABLE (g MATCH (v:v)-[e2:e2]->(w:w) COLUMNS (v.id, w.id));
 ----
 1	2
+
+statement ok
+CREATE TABLE a (
+    id BIGINT,
+    name VARCHAR
+);
+
+statement error
+CREATE TABLE b (
+    name VARCHAR,
+    src BIGINT REFERENCES a(id),
+    dst BIGINT,
+);
+----
+Binder Error: Failed to create foreign key: there is no primary key or unique constraint for referenced table "a"
+
+statement ok
+CREATE TABLE b (
+    name VARCHAR,
+    src BIGINT,
+    dst BIGINT,
+);
+
+statement error
+-CREATE PROPERTY GRAPH g2 VERTEX TABLES (a) EDGE TABLES (b SOURCE a DESTINATION a);
+----
+Invalid Error: No primary key - foreign key relationship found in b with source table a
+
+statement ok
+CREATE TABLE a_pk (
+    id BIGINT primary key,
+    name VARCHAR
+);
+
+statement ok
+CREATE TABLE b_pk (
+    name VARCHAR,
+    src BIGINT REFERENCES a_pk(id),
+    dst BIGINT,
+);
+
+statement ok
+-CREATE PROPERTY GRAPH g2 VERTEX TABLES (a_pk) EDGE TABLES (b_pk SOURCE a_pk DESTINATION a_pk);

--- a/test/sql/create_pg/create_pg_with_pk_fk.test
+++ b/test/sql/create_pg/create_pg_with_pk_fk.test
@@ -16,8 +16,8 @@ INSERT INTO v VALUES (1, 'a');
 statement ok
 create table e (
     id bigint primary key,
-    src BIGINT references v(id),
-    dst BIGINT references v(id)
+    src BIGINT REFERENCES v(id),
+    dst BIGINT REFERENCES v(id)
 );
 
 statement error
@@ -25,7 +25,7 @@ statement error
 vertex tables (v)
 edge tables (e source v destination v);
 ----
-Invalid Error: Multiple primary key - foreign key relationships detected with the same table. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> references v <foreign key>`
+Invalid Error: Multiple primary key - foreign key relationships detected with the same table. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> REFERENCES v <foreign key>`
 
 statement ok
 create table w (
@@ -39,8 +39,8 @@ INSERT INTO w VALUES (2, 'b');
 statement ok
 create table e2 (
     id bigint primary key,
-    src BIGINT references v(id),
-    dst BIGINT references w(id)
+    src BIGINT REFERENCES v(id),
+    dst BIGINT REFERENCES w(id)
 );
 
 statement ok
@@ -124,7 +124,7 @@ statement error
 VERTEX TABLES (x)
 EDGE TABLES (y SOURCE x DESTINATION x);
 ----
-Invalid Error: Multiple primary key - foreign key relationships detected with the same table. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> references x <foreign key>`
+Invalid Error: Multiple primary key - foreign key relationships detected with the same table. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> REFERENCES x <foreign key>`
 
 statement ok
 -CREATE PROPERTY GRAPH g3_explicit
@@ -244,7 +244,7 @@ statement error
 VERTEX TABLES (node_a)
 EDGE TABLES (edge_a SOURCE node_a DESTINATION KEY (dst) REFERENCES node_a (id));
 ----
-Invalid Error: Multiple primary key - foreign key relationships detected with the same table. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> references node_a <foreign key>`
+Invalid Error: Multiple primary key - foreign key relationships detected with the same table. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> REFERENCES node_a <foreign key>`
 
 statement ok
 -CREATE PROPERTY GRAPH g10

--- a/test/sql/create_pg/create_pg_with_pk_fk.test
+++ b/test/sql/create_pg/create_pg_with_pk_fk.test
@@ -11,13 +11,54 @@ create table v (
 );
 
 statement ok
-create table e (
-    id bigint primary key,
-    v_id BIGINT references v(id)
-);
+INSERT INTO v VALUES (1, 'a');
 
 statement ok
+create table e (
+    id bigint primary key,
+    src BIGINT references v(id),
+    dst BIGINT references v(id)
+);
+
+statement error
 -create property graph g
 vertex tables (v)
 edge tables (e source v destination v);
+----
+Invalid Error: Multiple primary key - foreign key relationships detected with the same table. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> references v <foreign key>`
 
+statement ok
+create table w (
+    id BIGINT primary key,
+    name varchar
+);
+
+statement ok
+INSERT INTO w VALUES (2, 'b');
+
+statement ok
+create table e2 (
+    id bigint primary key,
+    src BIGINT references v(id),
+    dst BIGINT references w(id)
+);
+
+statement ok
+INSERT INTO e2 VALUES (1, 1, 2);
+
+statement error
+-create property graph g
+vertex tables (v)
+edge tables (e2 source v destination w);
+----
+Invalid Error: Referenced vertex table w is not registered in the vertex tables
+
+statement ok
+-create property graph g
+vertex tables (v, w)
+edge tables (e2 source v destination w);
+
+query II
+-FROM GRAPH_TABLE (g MATCH (v:v)-[e2:e2]->(w:w) COLUMNS (v.id, w.id));
+----
+1	2

--- a/test/sql/create_pg/create_pg_with_pk_fk.test
+++ b/test/sql/create_pg/create_pg_with_pk_fk.test
@@ -1,0 +1,23 @@
+# name: test/sql/create_pg/create_pg_with_pk_fk.test
+# description: Testing create with predefined primary and foreign keys
+# group: [duckpgq_sql_create_pg]
+
+require duckpgq
+
+statement ok
+create table v (
+    id BIGINT primary key,
+    name varchar
+);
+
+statement ok
+create table e (
+    id bigint primary key,
+    v_id BIGINT references v(id)
+);
+
+statement ok
+-create property graph g
+vertex tables (v)
+edge tables (e source v destination v);
+

--- a/test/sql/create_pg/create_pg_with_pk_fk.test
+++ b/test/sql/create_pg/create_pg_with_pk_fk.test
@@ -127,11 +127,12 @@ EDGE TABLES (y SOURCE x DESTINATION x);
 Invalid Error: Multiple primary key - foreign key relationships detected with the same table. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> references x <foreign key>`
 
 statement ok
-CREATE PROPERTY GRAPH g3_explicit
+-CREATE PROPERTY GRAPH g3_explicit
 VERTEX TABLES (x)
-EDGE TABLES (y SOURCE KEY src REFERENCES x(id) DESTINATION KEY dst REFERENCES x(id));
+EDGE TABLES (y SOURCE KEY (src) REFERENCES x (id)
+                             DESTINATION KEY (dst) REFERENCES x (id));
 
-query II
+query I
 -FROM GRAPH_TABLE (g3_explicit MATCH (x:x)-[y:y]->(x:x) COLUMNS (x.id));
 ----
 
@@ -153,7 +154,7 @@ statement error
 VERTEX TABLES (m)
 EDGE TABLES (n SOURCE m DESTINATION m);
 ----
-Invalid Error: No primary key - foreign key relationship found in n with source table m
+Invalid Error: The primary key for the source table m is not defined in the edge table n
 
 
 

--- a/test/sql/create_pg/create_pg_with_pk_fk.test
+++ b/test/sql/create_pg/create_pg_with_pk_fk.test
@@ -25,7 +25,7 @@ statement error
 vertex tables (v)
 edge tables (e source v destination v);
 ----
-Invalid Error: Multiple primary key - foreign key relationships detected with the same table. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> REFERENCES v <foreign key>`
+Invalid Error: Multiple primary key - foreign key relationships detected between e and v. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> REFERENCES v <foreign key>`
 
 statement ok
 create table w (
@@ -88,7 +88,7 @@ CREATE TABLE b (
 statement error
 -CREATE PROPERTY GRAPH g2 VERTEX TABLES (a) EDGE TABLES (b SOURCE a DESTINATION a);
 ----
-Invalid Error: No primary key - foreign key relationship found in b with source table a
+Invalid Error: No primary key - foreign key relationship found in b with SOURCE table a
 
 statement ok
 CREATE TABLE a_pk (
@@ -124,7 +124,14 @@ statement error
 VERTEX TABLES (x)
 EDGE TABLES (y SOURCE x DESTINATION x);
 ----
-Invalid Error: Multiple primary key - foreign key relationships detected with the same table. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> REFERENCES x <foreign key>`
+Invalid Error: Multiple primary key - foreign key relationships detected between y and x. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> REFERENCES x <foreign key>`
+
+statement error
+-CREATE PROPERTY GRAPH g3
+VERTEX TABLES (x)
+EDGE TABLES (y SOURCE KEY (src) REFERENCES x (id) DESTINATION x);
+----
+Invalid Error: Multiple primary key - foreign key relationships detected between y and x. Please explicitly define the primary key and foreign key columns using `DESTINATION KEY <primary key> REFERENCES x <foreign key>`
 
 statement ok
 -CREATE PROPERTY GRAPH g3_explicit
@@ -154,7 +161,7 @@ statement error
 VERTEX TABLES (m)
 EDGE TABLES (n SOURCE m DESTINATION m);
 ----
-Invalid Error: The primary key for the source table m is not defined in the edge table n
+Invalid Error: The primary key for the SOURCE table m is not defined in the edge table n
 
 statement error
 -CREATE PROPERTY GRAPH g4
@@ -244,7 +251,7 @@ statement error
 VERTEX TABLES (node_a)
 EDGE TABLES (edge_a SOURCE node_a DESTINATION KEY (dst) REFERENCES node_a (id));
 ----
-Invalid Error: Multiple primary key - foreign key relationships detected with the same table. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> REFERENCES node_a <foreign key>`
+Invalid Error: Multiple primary key - foreign key relationships detected between edge_a and node_a. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> REFERENCES node_a <foreign key>`
 
 statement ok
 -CREATE PROPERTY GRAPH g10

--- a/test/sql/create_pg/create_property_graph.test
+++ b/test/sql/create_pg/create_property_graph.test
@@ -11,7 +11,7 @@ statement error
 -CREATE PROPERTY GRAPH pg4
 VERTEX TABLES (tabledoesnotexist);
 ----
-Invalid Error: tabledoesnotexist does not exist
+Invalid Error: Table tabledoesnotexist not found
 
 
 statement ok
@@ -24,7 +24,7 @@ EDGE TABLES (edgetabledoesnotexist SOURCE KEY (id) REFERENCES Student (id)
                                     DESTINATION KEY (id) REFERENCES Student (id)
             );
 ----
-Invalid Error: edgetabledoesnotexist does not exist
+Invalid Error: Table edgetabledoesnotexist not found
 
 statement ok
 CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);
@@ -147,7 +147,7 @@ EDGE TABLES (
             PROPERTIES ( createDate ) LABEL Knows
     )
 ----
-Invalid Error: Referenced vertex table Student does not exist.
+Invalid Error: Referenced vertex table Student is not registered in the vertex tables.
 
 
 # Should fail since the edge table references vertex tables that do not exist
@@ -162,7 +162,7 @@ EDGE TABLES (
             PROPERTIES ( createDate ) LABEL Knows
     );
 ----
-Invalid Error: Referenced vertex table Student does not exist.
+Invalid Error: Referenced vertex table Student is not registered in the vertex tables.
 
 
 # Check duplicate labels


### PR DESCRIPTION
Fixes #41 
Duckdb-pgq changes: https://github.com/cwida/duckdb-pgq/pull/203

This PR introduces more concise syntax during property graph creation if a primary key - foreign key relationship has already been defined between the vertex and edge tables. 
For the following schema: 
```sql
CREATE OR REPLACE TABLE a (
    id BIGINT PRIMARY KEY,
    name VARCHAR
);
CREATE OR REPLACE TABLE b (
    id BIGINT PRIMARY KEY,
    description VARCHAR
);
CREATE TABLE edge_ab (
    id BIGINT PRIMARY KEY,
    src BIGINT REFERENCES a(id),
    dst BIGINT REFERENCES b(id)
);
```

The following now suffices: 
```sql
CREATE PROPERTY GRAPH g_relationship
VERTEX TABLES (a, b)
EDGE TABLES (edge_ab SOURCE a DESTINATION b);
```

Previously, the pk-fk relationship was still required to be repeated for both the source and destination, even if it had already been defined earlier. Of course, if the vertex and edge tables do not specify any relationship explicitly mentioning it during the property graph creation is still required. 

```sql
CREATE TABLE Person(
	id BIGINT PRIMARY KEY
);

CREATE TABLE Person_knows_Person(
	creationDate TIMESTAMP WITH TIME ZONE NOT NULL, 
	Person1Id BIGINT REFERENCES Person (id), 
	Person2Id BIGINT REFERENCES Person (id));

CREATE PROPERTY GRAPH (snb 
VERTEX TABLES (Person)
EDGE TABLES (Person_knows_Person SOURCE Person DESTINATION Person); 
```
```
Invalid Error: Multiple primary key - foreign key relationships detected between Person_knows_Person and Person. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> REFERENCES Person <foreign key>`
```

If there is more than one pk-fk relationship to the same table (e.g. Person_knows_Person) and the shorthand syntax is used, an error will be thrown as it is impossible to deduce which of the relations is implied. 
