### PR TITLE
Improved error messages for incorrect labels

### DIFF
--- a/src/core/utils/duckpgq_utils.cpp
+++ b/src/core/utils/duckpgq_utils.cpp
@@ -33,11 +33,11 @@ CreatePropertyGraphInfo* GetPropertyGraphInfo(const shared_ptr<DuckPGQState> &du
 
 // Function to validate the source node and edge table
 shared_ptr<PropertyGraphTable> ValidateSourceNodeAndEdgeTable(CreatePropertyGraphInfo *pg_info, const std::string &node_table, const std::string &edge_table) {
-  auto source_node_pg_entry = pg_info->GetTable(node_table);
+  auto source_node_pg_entry = pg_info->GetTable(node_table, true, true);
   if (!source_node_pg_entry->is_vertex_table) {
     throw Exception(ExceptionType::INVALID, node_table + " is an edge table, expected a vertex table");
   }
-  auto edge_pg_entry = pg_info->GetTable(edge_table);
+  auto edge_pg_entry = pg_info->GetTable(edge_table, true, false);
   if (edge_pg_entry->is_vertex_table) {
     throw Exception(ExceptionType::INVALID, edge_table + " is a vertex table, expected an edge table");
   }

--- a/test/sql/scalar/local_clustering_coefficient.test
+++ b/test/sql/scalar/local_clustering_coefficient.test
@@ -68,58 +68,6 @@ EDGE TABLES (
             DESTINATION KEY ( dst ) REFERENCES Student ( id )
     );
 
-
-
-#
-#query II
-#WITH cte1 AS (
-#    SELECT  CREATE_CSR_EDGE(
-#            0,
-#            (SELECT count(a.id) FROM Student a),
-#            CAST (
-#                (SELECT sum(CREATE_CSR_VERTEX(
-#                            0,
-#                            (SELECT count(a.id) FROM Student a),
-#                            sub.dense_id,
-#                            sub.cnt)
-#                            ) * 2
-#                FROM (
-#                    SELECT dense_id, count(*) as cnt FROM (
-#                        SELECT dense_id, outgoing_edge, incoming_edge
-#                            FROM (
-#                                SELECT a.rowid AS dense_id, k.src AS outgoing_edge, k.dst AS incoming_edge
-#                                FROM Student a
-#                                JOIN Know k ON k.src = a.id
-#                                UNION ALL
-#                                SELECT a.rowid AS dense_id, k.dst AS outgoing_edge, k.src AS incoming_edge
-#                                FROM Student a
-#                                JOIN know k on k.dst = a.id)
-#                        GROUP BY dense_id, outgoing_edge, incoming_edge)
-#                   GROUP BY dense_id) sub
-#                )
-#            AS BIGINT),
-#            src,
-#            dst,
-#            edge) as temp FROM (
-#    select src, dst, any_value(edge) as edge FROM (
-#        select a.rowid as src, c.rowid as dst, k.rowid as edge FROM Know k
-#        JOIN Student a on a.id = k.src
-#        JOIN Student c on c.id = k.dst
-#        UNION ALL
-#        select a.rowid as src, c.rowid as dst, k.rowid as edge FROM Know k
-#        JOIN Student a on a.id = k.dst
-#        JOIN Student c on c.id = k.src)
-#    GROUP BY src, dst)
-#) SELECT __x.temp + local_clustering_coefficient(0, a.rowid) as lcc, a.name
-#        FROM (select count(cte1.temp) * 0 as temp from cte1) __x, Student a
-#        ORDER BY lcc DESC;
-#----
-#1.0	Daniel
-#1.0	Tavneet
-#1.0	Gabor
-#0.5	Peter
-#0.0	David
-
 query II
 select id, local_clustering_coefficient from local_clustering_coefficient(pg, student, know);
 ----
@@ -146,22 +94,22 @@ Invalid Error: Property graph pgdoesnotexist not found
 statement error
 select local_clustering_coefficient from local_clustering_coefficient(pg, a, know), student a where a.id = lcc.id;
 ----
-Invalid Error: Table a not found in property graph pg
+Invalid Error: Label 'a' not found. Did you mean the vertex label 'foo'?
 
 statement error
 select local_clustering_coefficient from local_clustering_coefficient(pg, student, b), student a where a.id = lcc.id;
 ----
-Invalid Error: Table b not found in property graph pg
+Invalid Error: Label 'b' not found. Did you mean the edge label 'know'?
 
 statement error
 select local_clustering_coefficient from local_clustering_coefficient(pg, foo, student), student a where a.id = lcc.id;
 ----
-Invalid Error: student is a vertex table, expected an edge table
+Invalid Error: Exact label 'student' found, but it is not a edge table.
 
 statement error
 select local_clustering_coefficient from local_clustering_coefficient(pg, student, foo), student a where a.id = lcc.id;
 ----
-Invalid Error: foo is a vertex table, expected an edge table
+Invalid Error: Exact label 'foo' found, but it is not a edge table.
 
 statement ok
 import database 'duckdb-pgq/data/SNB0.003';

--- a/test/sql/scalar/weakly_connected_component.test
+++ b/test/sql/scalar/weakly_connected_component.test
@@ -308,7 +308,7 @@ statement ok
 -CREATE OR REPLACE PROPERTY GRAPH my_graph
   VERTEX TABLES (
    nodes LABEL nodes,
-   thisisadifferenttable
+   thisisadifferenttable label thisisadifferenttablelabel
  )
   EDGE TABLES (
     edges SOURCE KEY (source) REFERENCES nodes (id)
@@ -344,5 +344,5 @@ Invalid Error: Label 'qaaaaaa' not found. Did you mean the vertex label 'nodes'?
 statement error
 SELECT * FROM weakly_connected_component(my_graph, thisisadifferent, knows);
 ----
-Invalid Error: Label 'thisisadifferent' not found. Did you mean the vertex label 'thisisadifferenttable'?
+Invalid Error: Label 'thisisadifferent' not found. Did you mean the vertex label 'thisisadifferenttablelabel'?
 

--- a/test/sql/scalar/weakly_connected_component.test
+++ b/test/sql/scalar/weakly_connected_component.test
@@ -4,279 +4,317 @@
 
 require duckpgq
 
-statement ok
-CREATE TABLE Student(id BIGINT, name VARCHAR);INSERT INTO Student VALUES (0, 'Daniel'), (1, 'Tavneet'), (2, 'Gabor'), (3, 'Peter'), (4, 'David');
+#statement ok
+#CREATE TABLE Student(id BIGINT, name VARCHAR);INSERT INTO Student VALUES (0, 'Daniel'), (1, 'Tavneet'), (2, 'Gabor'), (3, 'Peter'), (4, 'David');
+#
+#statement ok
+#CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (3,0, 13), (1,2, 14), (1,3, 15), (2,3, 16), (4,3, 17);
+#
+#statement ok
+#CREATE TABLE Foo(id BIGINT);INSERT INTO Foo VALUES (0), (1), (2), (3), (4);
+#
+#statement ok
+#-CREATE PROPERTY GRAPH pg
+#VERTEX TABLES (
+#    Student,
+#    Foo
+#    )
+#EDGE TABLES (
+#    know    SOURCE KEY ( src ) REFERENCES Student ( id )
+#            DESTINATION KEY ( dst ) REFERENCES Student ( id )
+#    );
+#
+#query II
+#select id, componentId from weakly_connected_component(pg, student, know);
+#----
+#0	0
+#1	0
+#2	0
+#3	0
+#4	0
+#
+#statement ok
+#CREATE OR REPLACE TABLE Student(id BIGINT, name VARCHAR);
+#INSERT INTO Student VALUES (0, 'Alice'), (1, 'Bob'), (2, 'Charlie'), (3, 'David'), (4, 'Eve');
+#
+#statement ok
+#CREATE OR REPLACE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);
+#INSERT INTO know VALUES (0, 0, 10), (1, 1, 11), (2, 2, 12), (3, 3, 13), (4, 4, 14);
+## Self loops
+#
+#statement ok
+#-CREATE OR REPLACE PROPERTY GRAPH pg_disconnected
+#VERTEX TABLES (
+#    Student
+#)
+#EDGE TABLES (
+#    know SOURCE KEY ( src ) REFERENCES Student ( id )
+#         DESTINATION KEY ( dst ) REFERENCES Student ( id )
+#);
+#
+#query II
+#select id, componentId from weakly_connected_component(pg_disconnected, student, know);
+#----
+#0	0
+#1	1
+#2	2
+#3	3
+#4	4
+#
+#statement ok
+#CREATE OR REPLACE TABLE Student(id BIGINT, name VARCHAR);
+#INSERT INTO Student VALUES (0, 'Alice'), (1, 'Bob'), (2, 'Charlie'), (3, 'David'), (4, 'Eve'), (5, 'Frank');
+#
+#statement ok
+#CREATE OR REPLACE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);
+#INSERT INTO know VALUES (0, 1, 10), (1, 2, 11), (2, 3, 12), (3, 0, 13);
+#
+#statement ok
+#-CREATE OR REPLACE PROPERTY GRAPH pg_isolated
+#VERTEX TABLES (
+#    Student
+#)
+#EDGE TABLES (
+#    know SOURCE KEY ( src ) REFERENCES Student ( id )
+#         DESTINATION KEY ( dst ) REFERENCES Student ( id )
+#);
+#
+#query II
+#select id, componentId from weakly_connected_component(pg_isolated, student, know);
+#----
+#0	0
+#1	0
+#2	0
+#3	0
+#4	4
+#5	5
+#
+#
+#statement ok
+#CREATE OR REPLACE TABLE Student(id BIGINT, name VARCHAR);
+#INSERT INTO Student VALUES (0, 'Alice'), (1, 'Bob'), (2, 'Charlie'), (3, 'David'), (4, 'Eve');
+#
+#statement ok
+#CREATE OR REPLACE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);
+#INSERT INTO know VALUES (0, 1, 10), (1, 2, 11), (3, 4, 12);
+#
+#statement ok
+#-CREATE OR REPLACE PROPERTY GRAPH pg_two_components
+#VERTEX TABLES (
+#    Student
+#)
+#EDGE TABLES (
+#    know SOURCE KEY ( src ) REFERENCES Student ( id )
+#         DESTINATION KEY ( dst ) REFERENCES Student ( id )
+#);
+#
+#query II
+#select id, componentId from weakly_connected_component(pg_two_components, student, know);
+#----
+#0	0
+#1	0
+#2	0
+#3	3
+#4	3
+#
+#statement ok
+#CREATE OR REPLACE TABLE Student(id BIGINT, name VARCHAR);
+#INSERT INTO Student VALUES (0, 'Alice'), (1, 'Bob'), (2, 'Charlie'), (3, 'David'), (4, 'Eve');
+#
+#statement ok
+#CREATE OR REPLACE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);
+#INSERT INTO know VALUES (0, 1, 10), (1, 2, 11), (2, 3, 12), (3, 0, 13), (3, 4, 14);
+#
+#statement ok
+#-CREATE OR REPLACE PROPERTY GRAPH pg_cyclic
+#VERTEX TABLES (
+#    Student
+#)
+#EDGE TABLES (
+#    know SOURCE KEY ( src ) REFERENCES Student ( id )
+#         DESTINATION KEY ( dst ) REFERENCES Student ( id )
+#);
+#
+#query II
+#select id, componentId from weakly_connected_component(pg_cyclic, student, know);
+#----
+#0	0
+#1	0
+#2	0
+#3	0
+#4	0
+#
+#statement ok
+#CREATE OR REPLACE TABLE Student(id BIGINT, name VARCHAR);
+#INSERT INTO Student VALUES (0, 'Node0'), (1, 'Node1'), (2, 'Node2'), (3, 'Node3'),
+#                           (4, 'Node4'), (5, 'Node5'), (6, 'Node6'), (7, 'Node7'),
+#                           (8, 'Node8'), (9, 'Node9');
+#
+#statement ok
+#CREATE OR REPLACE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);
+#INSERT INTO know VALUES (0, 1, 10), (1, 2, 11), (2, 3, 12), (3, 4, 13),
+#                        (5, 6, 14), (6, 7, 15), (7, 8, 16), (8, 9, 17),
+#                        (0, 4, 18), (5, 9, 19);
+#
+#statement ok
+#-CREATE OR REPLACE PROPERTY GRAPH pg_larger_graph
+#VERTEX TABLES (
+#    Student
+#)
+#EDGE TABLES (
+#    know SOURCE KEY ( src ) REFERENCES Student ( id )
+#         DESTINATION KEY ( dst ) REFERENCES Student ( id )
+#);
+#
+#query II
+#select id, componentId from weakly_connected_component(pg_larger_graph, student, know);
+#----
+#0	0
+#1	0
+#2	0
+#3	0
+#4	0
+#5	5
+#6	5
+#7	5
+#8	5
+#9	5
+#
+#statement error
+#select id, componentId from weakly_connected_component(non_existent_graph, student, know);
+#----
+#Invalid Error: Property graph non_existent_graph not found
+#
+#statement error
+#-CREATE PROPERTY GRAPH pg_no_vertex_table
+#EDGE TABLES (
+#    know SOURCE KEY ( src ) REFERENCES Student ( id )
+#         DESTINATION KEY ( dst ) REFERENCES Student ( id )
+#);
+#----
+#Parser Error: syntax error at or near "EDGE"
+#
+#statement error
+#select id, componentId from weakly_connected_component(pg_no_vertex_table, non_existent_vertex, know);
+#----
+#Invalid Error: Property graph pg_no_vertex_table not found
+#
+#statement ok
+#CREATE OR REPLACE TABLE Student(id BIGINT, name VARCHAR);
+#INSERT INTO Student VALUES (0, 'Alice'), (1, 'Bob');
+#
+#statement ok
+#-CREATE PROPERTY GRAPH pg_no_edge_table
+#VERTEX TABLES (
+#    Student
+#);
+#
+#statement error
+#select id, componentId from weakly_connected_component(pg_no_edge_table, student, non_existent_edge);
+#----
+#Invalid Error: Table non_existent_edge not found in property graph pg_no_edge_table
+#
+#statement ok
+#import database 'duckdb-pgq/data/SNB0.003';
+#
+#statement ok
+#-CREATE PROPERTY GRAPH snb
+#    VERTEX TABLES (
+#        Person
+#        )
+#    EDGE TABLES (
+#        Person_knows_person     SOURCE KEY (Person1Id) REFERENCES Person (id)
+#                                DESTINATION KEY (Person2Id) REFERENCES Person (id)
+#                                LABEL Knows);
+#
+#query II
+#from weakly_connected_component(snb, person, knows) order by componentId;
+#----
+#14	0
+#16	0
+#32	0
+#2199023255557	0
+#2199023255573	0
+#2199023255594	0
+#6597069766702	0
+#8796093022237	0
+#8796093022244	0
+#8796093022249	0
+#10995116277761	0
+#10995116277782	0
+#13194139533342	0
+#13194139533352	0
+#13194139533355	0
+#15393162788877	0
+#17592186044443	0
+#17592186044461	0
+#19791209299968	0
+#19791209299987	0
+#21990232555527	0
+#24189255811081	0
+#24189255811109	0
+#26388279066632	0
+#26388279066641	0
+#26388279066655	0
+#26388279066658	0
+#26388279066668	0
+#28587302322180	0
+#28587302322191	0
+#28587302322196	0
+#28587302322204	0
+#28587302322223	0
+#30786325577731	0
+#30786325577740	0
+#32985348833329	0
+#35184372088834	0
+#35184372088850	0
+#35184372088856	0
+#4398046511139	6
+#8796093022234	8
+#10995116277783	14
+#10995116277808	15
+#21990232555526	24
+#28587302322209	37
+#32985348833291	41
+#32985348833318	42
+#35184372088871	47
+#37383395344394	48
+#37383395344409	49
 
 statement ok
-CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (3,0, 13), (1,2, 14), (1,3, 15), (2,3, 16), (4,3, 17);
-
-statement ok
-CREATE TABLE Foo(id BIGINT);INSERT INTO Foo VALUES (0), (1), (2), (3), (4);
-
-statement ok
--CREATE PROPERTY GRAPH pg
-VERTEX TABLES (
-    Student,
-    Foo
-    )
-EDGE TABLES (
-    know    SOURCE KEY ( src ) REFERENCES Student ( id )
-            DESTINATION KEY ( dst ) REFERENCES Student ( id )
-    );
-
-query II
-select id, componentId from weakly_connected_component(pg, student, know);
-----
-0	0
-1	0
-2	0
-3	0
-4	0
-
-statement ok
-CREATE OR REPLACE TABLE Student(id BIGINT, name VARCHAR);
-INSERT INTO Student VALUES (0, 'Alice'), (1, 'Bob'), (2, 'Charlie'), (3, 'David'), (4, 'Eve');
-
-statement ok
-CREATE OR REPLACE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);
-INSERT INTO know VALUES (0, 0, 10), (1, 1, 11), (2, 2, 12), (3, 3, 13), (4, 4, 14);
-# Self loops
-
-statement ok
--CREATE OR REPLACE PROPERTY GRAPH pg_disconnected
-VERTEX TABLES (
-    Student
-)
-EDGE TABLES (
-    know SOURCE KEY ( src ) REFERENCES Student ( id )
-         DESTINATION KEY ( dst ) REFERENCES Student ( id )
+CREATE or replace TABLE edges (
+    source INTEGER,
+    target INTEGER
 );
 
-query II
-select id, componentId from weakly_connected_component(pg_disconnected, student, know);
-----
-0	0
-1	1
-2	2
-3	3
-4	4
+statement ok
+INSERT INTO edges VALUES (1, 2), (2, 3), (4, 5), (2, 4), (10,11);
 
 statement ok
-CREATE OR REPLACE TABLE Student(id BIGINT, name VARCHAR);
-INSERT INTO Student VALUES (0, 'Alice'), (1, 'Bob'), (2, 'Charlie'), (3, 'David'), (4, 'Eve'), (5, 'Frank');
+CREATE OR REPLACE TABLE nodes AS
+   (SELECT DISTINCT id FROM
+    (SELECT DISTINCT source AS id FROM edges
+    UNION
+    SELECT DISTINCT target AS id FROM edges
+    ) );
 
 statement ok
-CREATE OR REPLACE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);
-INSERT INTO know VALUES (0, 1, 10), (1, 2, 11), (2, 3, 12), (3, 0, 13);
-
-statement ok
--CREATE OR REPLACE PROPERTY GRAPH pg_isolated
-VERTEX TABLES (
-    Student
-)
-EDGE TABLES (
-    know SOURCE KEY ( src ) REFERENCES Student ( id )
-         DESTINATION KEY ( dst ) REFERENCES Student ( id )
-);
-
-query II
-select id, componentId from weakly_connected_component(pg_isolated, student, know);
-----
-0	0
-1	0
-2	0
-3	0
-4	4
-5	5
-
-
-statement ok
-CREATE OR REPLACE TABLE Student(id BIGINT, name VARCHAR);
-INSERT INTO Student VALUES (0, 'Alice'), (1, 'Bob'), (2, 'Charlie'), (3, 'David'), (4, 'Eve');
-
-statement ok
-CREATE OR REPLACE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);
-INSERT INTO know VALUES (0, 1, 10), (1, 2, 11), (3, 4, 12);
-
-statement ok
--CREATE OR REPLACE PROPERTY GRAPH pg_two_components
-VERTEX TABLES (
-    Student
-)
-EDGE TABLES (
-    know SOURCE KEY ( src ) REFERENCES Student ( id )
-         DESTINATION KEY ( dst ) REFERENCES Student ( id )
-);
-
-query II
-select id, componentId from weakly_connected_component(pg_two_components, student, know);
-----
-0	0
-1	0
-2	0
-3	3
-4	3
-
-statement ok
-CREATE OR REPLACE TABLE Student(id BIGINT, name VARCHAR);
-INSERT INTO Student VALUES (0, 'Alice'), (1, 'Bob'), (2, 'Charlie'), (3, 'David'), (4, 'Eve');
-
-statement ok
-CREATE OR REPLACE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);
-INSERT INTO know VALUES (0, 1, 10), (1, 2, 11), (2, 3, 12), (3, 0, 13), (3, 4, 14);
-
-statement ok
--CREATE OR REPLACE PROPERTY GRAPH pg_cyclic
-VERTEX TABLES (
-    Student
-)
-EDGE TABLES (
-    know SOURCE KEY ( src ) REFERENCES Student ( id )
-         DESTINATION KEY ( dst ) REFERENCES Student ( id )
-);
-
-query II
-select id, componentId from weakly_connected_component(pg_cyclic, student, know);
-----
-0	0
-1	0
-2	0
-3	0
-4	0
-
-statement ok
-CREATE OR REPLACE TABLE Student(id BIGINT, name VARCHAR);
-INSERT INTO Student VALUES (0, 'Node0'), (1, 'Node1'), (2, 'Node2'), (3, 'Node3'),
-                           (4, 'Node4'), (5, 'Node5'), (6, 'Node6'), (7, 'Node7'),
-                           (8, 'Node8'), (9, 'Node9');
-
-statement ok
-CREATE OR REPLACE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);
-INSERT INTO know VALUES (0, 1, 10), (1, 2, 11), (2, 3, 12), (3, 4, 13),
-                        (5, 6, 14), (6, 7, 15), (7, 8, 16), (8, 9, 17),
-                        (0, 4, 18), (5, 9, 19);
-
-statement ok
--CREATE OR REPLACE PROPERTY GRAPH pg_larger_graph
-VERTEX TABLES (
-    Student
-)
-EDGE TABLES (
-    know SOURCE KEY ( src ) REFERENCES Student ( id )
-         DESTINATION KEY ( dst ) REFERENCES Student ( id )
-);
-
-query II
-select id, componentId from weakly_connected_component(pg_larger_graph, student, know);
-----
-0	0
-1	0
-2	0
-3	0
-4	0
-5	5
-6	5
-7	5
-8	5
-9	5
+-CREATE OR REPLACE PROPERTY GRAPH my_graph
+  VERTEX TABLES (
+   nodes LABEL nodes
+ )
+  EDGE TABLES (
+    edges SOURCE KEY (source) REFERENCES nodes (id)
+          DESTINATION KEY (target) REFERENCES nodes (id)
+          LABEL knows
+  );
 
 statement error
-select id, componentId from weakly_connected_component(non_existent_graph, student, know);
+SELECT * FROM weakly_connected_component(my_graph, nodes, edges);
 ----
-Invalid Error: Property graph non_existent_graph not found
+Invalid Error: Table edges found in the property graph, but does not have the correct label. Did you mean the label knows instead?
 
 statement error
--CREATE PROPERTY GRAPH pg_no_vertex_table
-EDGE TABLES (
-    know SOURCE KEY ( src ) REFERENCES Student ( id )
-         DESTINATION KEY ( dst ) REFERENCES Student ( id )
-);
+SELECT * FROM weakly_connected_component(my_graph, nodes, kows);
 ----
-Parser Error: syntax error at or near "EDGE"
-
-statement error
-select id, componentId from weakly_connected_component(pg_no_vertex_table, non_existent_vertex, know);
-----
-Invalid Error: Property graph pg_no_vertex_table not found
-
-statement ok
-CREATE OR REPLACE TABLE Student(id BIGINT, name VARCHAR);
-INSERT INTO Student VALUES (0, 'Alice'), (1, 'Bob');
-
-statement ok
--CREATE PROPERTY GRAPH pg_no_edge_table
-VERTEX TABLES (
-    Student
-);
-
-statement error
-select id, componentId from weakly_connected_component(pg_no_edge_table, student, non_existent_edge);
-----
-Invalid Error: Table non_existent_edge not found in property graph pg_no_edge_table
-
-statement ok
-import database 'duckdb-pgq/data/SNB0.003';
-
-statement ok
--CREATE PROPERTY GRAPH snb
-    VERTEX TABLES (
-        Person
-        )
-    EDGE TABLES (
-        Person_knows_person     SOURCE KEY (Person1Id) REFERENCES Person (id)
-                                DESTINATION KEY (Person2Id) REFERENCES Person (id)
-                                LABEL Knows);
-
-query II
-from weakly_connected_component(snb, person, knows) order by componentId;
-----
-14	0
-16	0
-32	0
-2199023255557	0
-2199023255573	0
-2199023255594	0
-6597069766702	0
-8796093022237	0
-8796093022244	0
-8796093022249	0
-10995116277761	0
-10995116277782	0
-13194139533342	0
-13194139533352	0
-13194139533355	0
-15393162788877	0
-17592186044443	0
-17592186044461	0
-19791209299968	0
-19791209299987	0
-21990232555527	0
-24189255811081	0
-24189255811109	0
-26388279066632	0
-26388279066641	0
-26388279066655	0
-26388279066658	0
-26388279066668	0
-28587302322180	0
-28587302322191	0
-28587302322196	0
-28587302322204	0
-28587302322223	0
-30786325577731	0
-30786325577740	0
-32985348833329	0
-35184372088834	0
-35184372088850	0
-35184372088856	0
-4398046511139	6
-8796093022234	8
-10995116277783	14
-10995116277808	15
-21990232555526	24
-28587302322209	37
-32985348833291	41
-32985348833318	42
-35184372088871	47
-37383395344394	48
-37383395344409	49
+Invalid Error: Label 'kows' not found. Did you mean the edge label 'knows'?

--- a/test/sql/scalar/weakly_connected_component.test
+++ b/test/sql/scalar/weakly_connected_component.test
@@ -299,9 +299,16 @@ CREATE OR REPLACE TABLE nodes AS
     ) );
 
 statement ok
+CREATE TABLE thisisadifferenttable (id INTEGER);
+
+statement ok
+INSERT INTO thisisadifferenttable VALUES (1);
+
+statement ok
 -CREATE OR REPLACE PROPERTY GRAPH my_graph
   VERTEX TABLES (
-   nodes LABEL nodes
+   nodes LABEL nodes,
+   thisisadifferenttable
  )
   EDGE TABLES (
     edges SOURCE KEY (source) REFERENCES nodes (id)
@@ -312,9 +319,30 @@ statement ok
 statement error
 SELECT * FROM weakly_connected_component(my_graph, nodes, edges);
 ----
-Invalid Error: Table edges found in the property graph, but does not have the correct label. Did you mean the label knows instead?
+Invalid Error: Table 'edges' found in the property graph, but does not have the correct label. Did you mean the label 'knows' instead?
 
 statement error
 SELECT * FROM weakly_connected_component(my_graph, nodes, kows);
 ----
 Invalid Error: Label 'kows' not found. Did you mean the edge label 'knows'?
+
+statement error
+SELECT * FROM weakly_connected_component(my_graph, knows, knows);
+----
+Invalid Error: Exact label 'knows' found, but it is not a vertex table.
+
+statement error
+SELECT * FROM weakly_connected_component(my_graph, no, knows);
+----
+Invalid Error: Label 'no' not found. Did you mean the vertex label 'nodes'?
+
+statement error
+SELECT * FROM weakly_connected_component(my_graph, qaaaaaa, knows);
+----
+Invalid Error: Label 'qaaaaaa' not found. Did you mean the vertex label 'nodes'?
+
+statement error
+SELECT * FROM weakly_connected_component(my_graph, thisisadifferent, knows);
+----
+Invalid Error: Label 'thisisadifferent' not found. Did you mean the vertex label 'thisisadifferenttable'?
+


### PR DESCRIPTION
Fixes #148 
PR for DuckDB-PGQ: https://github.com/cwida/duckdb-pgq/pull/204
This PR improves the error messages if an unknown label was used in one of the graph table functions. Need to refactor the match statement to also use this in a future PR.

Documentation page has been updated as well: https://duckpgq.notion.site/Graph-functions-c6678b8a9a9a4bd7ab42166aa727bace?pvs=74

Example error for a spelling mistake:
`Invalid Error: Label 'kows' not found. Did you mean the edge label 'knows'?`

Suggestions take into account whether we are looking for a vertex label or an edge label. 

Also in case you use the table name, while a label (which is different) is used, a user should use the label instead: 
`Invalid Error: Table 'edges' found in the property graph, but does not have the correct label. Did you mean the label 'knows' instead?`
 
Giving an edge label where a vertex label is expected results in the following: 
`Invalid Error: Exact label 'knows' found, but it is not a vertex table.`
