### PR TITLE
Fix segmentation fault when doing top k queries

### DIFF
--- a/test/sql/path_finding/top_k.test
+++ b/test/sql/path_finding/top_k.test
@@ -1,0 +1,30 @@
+# name: test/sql/path_finding/top_k.test
+# description: Testing top-k functionality, not implemented yet.
+# group: [duckpgq_sql_path_finding]
+
+require duckpgq
+
+statement ok
+CREATE TABLE Student(id BIGINT, name VARCHAR); INSERT INTO Student VALUES (0, 'Daniel'), (1, 'Tavneet'), (2, 'Gabor'), (3, 'Peter'), (4, 'David');
+
+statement ok
+CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT); INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (3,0, 13), (1,2, 14), (1,3, 15), (2,3, 16), (4,3, 17);
+
+
+statement ok
+-CREATE PROPERTY GRAPH pg
+VERTEX TABLES (
+    Student LABEL person
+    )
+EDGE TABLES (
+    know    SOURCE KEY ( src ) REFERENCES Student ( id )
+            DESTINATION KEY ( dst ) REFERENCES Student ( id )
+            label knows
+    );
+
+
+statement ok
+-FROM GRAPH_TABLE (pg
+        MATCH
+        p = ANY SHORTEST 5 WALK (a:Person)-[k:knows]-> *(b:Person)
+        WHERE a.name = 'Daniel');

--- a/test/sql/path_finding/top_k.test
+++ b/test/sql/path_finding/top_k.test
@@ -22,9 +22,37 @@ EDGE TABLES (
             label knows
     );
 
+statement error
+-FROM GRAPH_TABLE (pg
+    MATCH
+    p = ANY SHORTEST 5 WALK (a:Person)-[k:knows]-> *(b:Person)
+    WHERE a.name = 'Daniel'
+    COLUMNS (p, a.name as name, b.name as school)
+    ) study;
+----
+Parser Error: syntax error at or near "5"
 
-statement ok
+
+statement error
 -FROM GRAPH_TABLE (pg
         MATCH
-        p = ANY SHORTEST 5 WALK (a:Person)-[k:knows]-> *(b:Person)
+        p =  SHORTEST 5 (a:Person)-[k:knows]-> *(b:Person)
         WHERE a.name = 'Daniel');
+----
+Not implemented Error: TopK has not been implemented yet.
+
+statement error
+-FROM GRAPH_TABLE (pg
+        MATCH
+        p =  SHORTEST 5 WALK (a:Person)-[k:knows]-> *(b:Person)
+        WHERE a.name = 'Daniel');
+----
+Not implemented Error: TopK has not been implemented yet.
+
+statement error
+-FROM GRAPH_TABLE (pg
+        MATCH
+        p =  ANY SHORTEST 5 WALK (a:Person)-[k:knows]-> *(b:Person)
+        WHERE a.name = 'Daniel');
+----
+Parser Error: syntax error at or near "5"

--- a/test/sql/path_finding/top_k.test
+++ b/test/sql/path_finding/top_k.test
@@ -10,7 +10,6 @@ CREATE TABLE Student(id BIGINT, name VARCHAR); INSERT INTO Student VALUES (0, 'D
 statement ok
 CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT); INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (3,0, 13), (1,2, 14), (1,3, 15), (2,3, 16), (4,3, 17);
 
-
 statement ok
 -CREATE PROPERTY GRAPH pg
 VERTEX TABLES (


### PR DESCRIPTION
Fixes https://github.com/cwida/duckpgq-extension/issues/46

This PR only fixes the segmentation fault users could get when trying top k queries with slightly incorrect syntax, such as the example query in the abovementioned issue. 

We do not yet support TopK queries. 
