### PR TITLE
Make property graphs persistent

### DIFF
--- a/src/core/functions/table/create_property_graph.cpp
+++ b/src/core/functions/table/create_property_graph.cpp
@@ -237,12 +237,102 @@ CreatePropertyGraphFunction::CreatePropertyGraphInit(
 void CreatePropertyGraphFunction::CreatePropertyGraphFunc(
     ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
   auto &bind_data = data_p.bind_data->Cast<CreatePropertyGraphBindData>();
-
   auto pg_info = bind_data.create_pg_info;
   auto duckpgq_state = GetDuckPGQState(context);
 
   duckpgq_state->registered_property_graphs[pg_info->property_graph_name] =
       pg_info->Copy();
+
+  auto new_conn = make_shared_ptr<ClientContext>(context.db);
+
+  auto retrieve_query = new_conn->Query("SELECT * FROM __duckpgq_internal where property_graph = '" + pg_info->property_graph_name + "';", false);
+  if (retrieve_query->HasError()) {
+    throw TransactionException(retrieve_query->GetError());
+  }
+  auto &query_result = retrieve_query->Cast<MaterializedQueryResult>();
+  if (query_result.RowCount() > 0) {
+    throw Exception(ExceptionType::INVALID, "Property graph " + pg_info->property_graph_name + " is already registered");
+  }
+
+  string insert_info = "INSERT INTO __duckpgq_internal VALUES ";
+  for (const auto &v_table : pg_info->vertex_tables) {
+    insert_info += "(";
+    insert_info += "'" + pg_info->property_graph_name + "', ";
+    insert_info += "'" + v_table->table_name + "', ";
+    insert_info += "'" + v_table->main_label + "', ";
+    insert_info += "true, "; // is_vertex_table
+    insert_info += "NULL, "; // source_table
+    insert_info += "NULL, "; // source_pk
+    insert_info += "NULL, "; // source_fk
+    insert_info += "NULL, "; // destination_table
+    insert_info += "NULL, "; // destination_pk
+    insert_info += "NULL, "; // destination_fk
+    insert_info += v_table->discriminator.empty() ? "NULL, " : "'" + v_table->discriminator + "', ";
+    if (!v_table->discriminator.empty()) {
+      insert_info += "[";
+      for (idx_t i = 0; i < v_table->sub_labels.size(); i++) {
+        insert_info += "'" + v_table->sub_labels[i] + (i == v_table->sub_labels.size() - 1 ? "'" : "', ");
+      }
+      insert_info += "]";
+    } else {
+      insert_info += "NULL";
+    }
+    insert_info += "), ";
+  }
+
+  for (const auto &e_table : pg_info->edge_tables) {
+    insert_info += "(";
+    insert_info += "'" + pg_info->property_graph_name + "', ";
+    insert_info += "'" + e_table->table_name + "', ";
+    insert_info += "'" + e_table->main_label + "', ";
+    insert_info += "false, "; // is_vertex_table
+    insert_info += "'" + e_table->source_reference + "', ";
+    insert_info += "[";
+    for (const auto &source_pk : e_table->source_pk) {
+      insert_info += "'" + source_pk + "', ";
+    }
+    insert_info += "], ";
+    insert_info += "[";
+    for (const auto &source_fk : e_table->source_fk) {
+      insert_info += "'" + source_fk + "', ";
+    }
+    insert_info += "], ";
+
+    insert_info += "'" + e_table->destination_reference + "', ";
+    insert_info += "[";
+    for (const auto &destination_pk : e_table->destination_pk) {
+      insert_info += "'" + destination_pk + "', ";
+    }
+    insert_info += "], ";
+    insert_info += "[";
+    for (const auto &destination_fk : e_table->destination_fk) {
+      insert_info += "'" + destination_fk + "', ";
+    }
+    insert_info += "], ";
+
+    insert_info += e_table->discriminator.empty() ? "NULL, " : "'" + e_table->discriminator + "', ";
+    if (!e_table->discriminator.empty()) {
+      insert_info += "[";
+      for (idx_t i = 0; i < e_table->sub_labels.size(); i++) {
+        insert_info += "'" + e_table->sub_labels[i] + (i == e_table->sub_labels.size() - 1 ? "'" : "', ");
+      }
+      insert_info += "]";
+    } else {
+      insert_info += "NULL";
+    }
+    insert_info += "), ";
+
+  }
+
+  auto insert_query = new_conn->Query(insert_info, false);
+
+  // TODO handle on conflict
+  if (insert_query->HasError()) {
+    throw TransactionException(insert_query->GetError());
+  }
+
+
+
 }
 
 //------------------------------------------------------------------------------

--- a/src/core/functions/table/drop_property_graph.cpp
+++ b/src/core/functions/table/drop_property_graph.cpp
@@ -53,6 +53,10 @@ void DropPropertyGraphFunction::DropPropertyGraphFunc(
                           pg_info->property_graph_name);
   }
   duckpgq_state->registered_property_graphs.erase(registered_pg);
+  auto new_conn = make_shared_ptr<ClientContext>(context.db);
+  new_conn->Query("DELETE FROM __duckpgq_internal where property_graph = '" +
+                      pg_info->property_graph_name + "'",
+                  false);
 }
 
 //------------------------------------------------------------------------------

--- a/src/core/parser/duckpgq_parser.cpp
+++ b/src/core/parser/duckpgq_parser.cpp
@@ -162,15 +162,11 @@ duckpgq_handle_statement(SQLStatement *statement, DuckPGQState &duckpgq_state) {
 ParserExtensionPlanResult
 duckpgq_plan(ParserExtensionInfo *, ClientContext &context,
              unique_ptr<ParserExtensionParseData> parse_data) {
-
   auto duckpgq_state = context.registered_state->Get<DuckPGQState>("duckpgq");
-  if (duckpgq_state== nullptr) {
-    auto state = make_shared_ptr<DuckPGQState>(std::move(parse_data));
-    context.registered_state->Insert("duckpgq", state);
-    duckpgq_state = context.registered_state->Get<DuckPGQState>("duckpgq");
-  } else {
-    duckpgq_state->parse_data = std::move(parse_data);
+  if (duckpgq_state == nullptr) {
+    throw Exception(ExceptionType::INVALID, "DuckPGQ has not been properly initialized");
   }
+  duckpgq_state->parse_data = std::move(parse_data);
   auto duckpgq_parse_data =
       dynamic_cast<DuckPGQParseData *>(duckpgq_state->parse_data.get());
 

--- a/src/core/parser/duckpgq_parser.cpp
+++ b/src/core/parser/duckpgq_parser.cpp
@@ -164,7 +164,7 @@ duckpgq_plan(ParserExtensionInfo *, ClientContext &context,
              unique_ptr<ParserExtensionParseData> parse_data) {
   auto duckpgq_state = context.registered_state->Get<DuckPGQState>("duckpgq");
   if (duckpgq_state == nullptr) {
-    throw Exception(ExceptionType::INVALID, "DuckPGQ has not been properly initialized");
+    throw Exception(ExceptionType::INVALID, "DuckPGQ extension has not been properly initialized");
   }
   duckpgq_state->parse_data = std::move(parse_data);
   auto duckpgq_parse_data =
@@ -185,8 +185,7 @@ duckpgq_plan(ParserExtensionInfo *, ClientContext &context,
 void CorePGQParser::RegisterPGQParserExtension(
     DatabaseInstance &db) {
   auto &config = DBConfig::GetConfig(db);
-  DuckPGQParserExtension pgq_parser;
-  config.parser_extensions.push_back(pgq_parser);
+  config.parser_extensions.push_back(DuckPGQParserExtension());
 }
 
 } // namespace core

--- a/src/duckpgq_extension.cpp
+++ b/src/duckpgq_extension.cpp
@@ -17,17 +17,6 @@ std::string DuckpgqExtension::Name() { return "duckpgq"; }
 
 } // namespace duckpgq
 
-extern "C" {
-
-DUCKDB_EXTENSION_API void duckpgq_init(DatabaseInstance &db) {
-  LoadInternal(db);
-}
-
-DUCKDB_EXTENSION_API const char *duckpgq_version() {
-  return DuckDB::LibraryVersion();
-}
-}
-
 #ifndef DUCKDB_EXTENSION_MAIN
 #error DUCKDB_EXTENSION_MAIN not defined
 #endif

--- a/src/duckpgq_extension.cpp
+++ b/src/duckpgq_extension.cpp
@@ -3,14 +3,18 @@
 #include "duckpgq_extension.hpp"
 #include "duckpgq/common.hpp"
 #include "duckpgq/core/module.hpp"
-
+#include <duckpgq_extension_callback.hpp>
+#include "duckdb/main/connection_manager.hpp"
 
 namespace duckdb {
 
 static void LoadInternal(DatabaseInstance &instance) {
   duckpgq::core::CoreModule::Register(instance);
   auto &config = DBConfig::GetConfig(instance);
-  config.extension_callbacks.push_back(make_uniq<DuckpgqLoadExtension>());
+  config.extension_callbacks.push_back(make_uniq<DuckpgqExtensionCallback>());
+  for (auto &connection : ConnectionManager::Get(instance).GetConnectionList()) {
+    connection->registered_state->Insert("duckpgq", make_shared_ptr<DuckPGQState>());
+  }
 }
 
 void DuckpgqExtension::Load(DuckDB &db) { LoadInternal(*db.instance); }

--- a/src/duckpgq_extension.cpp
+++ b/src/duckpgq_extension.cpp
@@ -13,7 +13,7 @@ static void LoadInternal(DatabaseInstance &instance) {
   auto &config = DBConfig::GetConfig(instance);
   config.extension_callbacks.push_back(make_uniq<DuckpgqExtensionCallback>());
   for (auto &connection : ConnectionManager::Get(instance).GetConnectionList()) {
-    connection->registered_state->Insert("duckpgq", make_shared_ptr<DuckPGQState>());
+    connection->registered_state->Insert("duckpgq", make_shared_ptr<DuckPGQState>(connection));
   }
 }
 

--- a/src/duckpgq_extension.cpp
+++ b/src/duckpgq_extension.cpp
@@ -9,6 +9,8 @@ namespace duckdb {
 
 static void LoadInternal(DatabaseInstance &instance) {
   duckpgq::core::CoreModule::Register(instance);
+  auto &config = DBConfig::GetConfig(instance);
+  config.extension_callbacks.push_back(make_uniq<DuckpgqLoadExtension>());
 }
 
 void DuckpgqExtension::Load(DuckDB &db) { LoadInternal(*db.instance); }

--- a/src/duckpgq_extension.cpp
+++ b/src/duckpgq_extension.cpp
@@ -23,6 +23,17 @@ std::string DuckpgqExtension::Name() { return "duckpgq"; }
 
 } // namespace duckpgq
 
+extern "C" {
+
+  DUCKDB_EXTENSION_API void duckpgq_init(DatabaseInstance &db) {
+    LoadInternal(db);
+  }
+
+  DUCKDB_EXTENSION_API const char *duckpgq_version() {
+    return DuckDB::LibraryVersion();
+  }
+}
+
 #ifndef DUCKDB_EXTENSION_MAIN
 #error DUCKDB_EXTENSION_MAIN not defined
 #endif

--- a/src/duckpgq_state.cpp
+++ b/src/duckpgq_state.cpp
@@ -45,22 +45,21 @@ void DuckPGQState::RetrievePropertyGraphs(shared_ptr<ClientContext> context) {
       // Handle edge table related things.
       table->source_reference = chunk->GetValue(4, i).GetValue<string>();
       auto source_pk_chunk = ListValue::GetChildren(chunk->GetValue(5, i));
-      for (const auto& source: source_pk_chunk) {
-        table->source_pk.push_back(source.GetValue<string>());
+      for (const auto& source_pk: source_pk_chunk) {
+        table->source_pk.push_back(source_pk.GetValue<string>());
       }
       auto source_fk_chunk = ListValue::GetChildren(chunk->GetValue(6, i));
-      for (const auto& destination: source_fk_chunk) {
-        table->source_fk.push_back(destination.GetValue<string>());
+      for (const auto& source_fk: source_fk_chunk) {
+        table->source_fk.push_back(source_fk.GetValue<string>());
       }
       table->destination_reference = chunk->GetValue(7, i).GetValue<string>();
       auto destination_pk_chunk = ListValue::GetChildren(chunk->GetValue(8, i));
-
-      for (const auto& source: destination_pk_chunk) {
-        table->destination_pk.push_back(source.GetValue<string>());
+      for (const auto& dest_pk: destination_pk_chunk) {
+        table->destination_pk.push_back(dest_pk.GetValue<string>());
       }
       auto destination_fk_chunk = ListValue::GetChildren(chunk->GetValue(9, i));
-      for (const auto& destination: destination_fk_chunk) {
-        table->destination_fk.push_back(destination.GetValue<string>());
+      for (const auto& dest_fk: destination_fk_chunk) {
+        table->destination_fk.push_back(dest_fk.GetValue<string>());
       }
     }
     string discriminator = chunk->GetValue(10, i).GetValue<string>();

--- a/src/duckpgq_state.cpp
+++ b/src/duckpgq_state.cpp
@@ -2,8 +2,7 @@
 
 namespace duckdb {
 
-DuckPGQState::DuckPGQState(unique_ptr<ParserExtensionParseData> parse_data)
-    : parse_data(std::move(parse_data)) {}
+DuckPGQState::DuckPGQState() = default;
 
 void DuckPGQState::QueryEnd() {
   parse_data.reset();

--- a/src/duckpgq_state.cpp
+++ b/src/duckpgq_state.cpp
@@ -5,22 +5,22 @@ namespace duckdb {
 DuckPGQState::DuckPGQState(shared_ptr<ClientContext> context) {
   auto new_conn = make_shared_ptr<ClientContext>(context->db);
   auto query = new_conn->Query("CREATE TABLE IF NOT EXISTS __duckpgq_internal ("
-                  "property_graph varchar, "
-                  "table_name varchar, "
-                  "label varchar, "
-                  "is_vertex_table boolean, "
-                  "source_table varchar, "
-                  "source_pk varchar[], "
-                  "source_fk varchar[], "
-                  "destination_table varchar, "
-                  "destination_pk varchar[], "
-                  "destination_fk varchar[], "
-                  "discriminator varchar, "
-                  "sub_labels varchar[])", false);
+                               "property_graph varchar, "
+                               "table_name varchar, "
+                               "label varchar, "
+                               "is_vertex_table boolean, "
+                               "source_table varchar, "
+                               "source_pk varchar[], "
+                               "source_fk varchar[], "
+                               "destination_table varchar, "
+                               "destination_pk varchar[], "
+                               "destination_fk varchar[], "
+                               "discriminator varchar, "
+                               "sub_labels varchar[])",
+                               false);
   if (query->HasError()) {
     throw TransactionException(query->GetError());
   }
-
 
   RetrievePropertyGraphs(new_conn);
 }
@@ -45,20 +45,20 @@ void DuckPGQState::RetrievePropertyGraphs(shared_ptr<ClientContext> context) {
       // Handle edge table related things.
       table->source_reference = chunk->GetValue(4, i).GetValue<string>();
       auto source_pk_chunk = ListValue::GetChildren(chunk->GetValue(5, i));
-      for (const auto& source_pk: source_pk_chunk) {
+      for (const auto &source_pk : source_pk_chunk) {
         table->source_pk.push_back(source_pk.GetValue<string>());
       }
       auto source_fk_chunk = ListValue::GetChildren(chunk->GetValue(6, i));
-      for (const auto& source_fk: source_fk_chunk) {
+      for (const auto &source_fk : source_fk_chunk) {
         table->source_fk.push_back(source_fk.GetValue<string>());
       }
       table->destination_reference = chunk->GetValue(7, i).GetValue<string>();
       auto destination_pk_chunk = ListValue::GetChildren(chunk->GetValue(8, i));
-      for (const auto& dest_pk: destination_pk_chunk) {
+      for (const auto &dest_pk : destination_pk_chunk) {
         table->destination_pk.push_back(dest_pk.GetValue<string>());
       }
       auto destination_fk_chunk = ListValue::GetChildren(chunk->GetValue(9, i));
-      for (const auto& dest_fk: destination_fk_chunk) {
+      for (const auto &dest_fk : destination_fk_chunk) {
         table->destination_fk.push_back(dest_fk.GetValue<string>());
       }
     }
@@ -66,15 +66,18 @@ void DuckPGQState::RetrievePropertyGraphs(shared_ptr<ClientContext> context) {
     if (discriminator != "NULL") {
       table->discriminator = discriminator;
       auto sublabels = ListValue::GetChildren(chunk->GetValue(11, i));
-      for (const auto& sublabel : sublabels) {
+      for (const auto &sublabel : sublabels) {
         table->sub_labels.push_back(sublabel.GetValue<string>());
       }
     }
 
-    if (registered_property_graphs.find(property_graph_name) == registered_property_graphs.end()) {
-      registered_property_graphs[property_graph_name] = make_uniq<CreatePropertyGraphInfo>(property_graph_name);
+    if (registered_property_graphs.find(property_graph_name) ==
+        registered_property_graphs.end()) {
+      registered_property_graphs[property_graph_name] =
+          make_uniq<CreatePropertyGraphInfo>(property_graph_name);
     }
-    auto &pg_info = registered_property_graphs[property_graph_name]->Cast<CreatePropertyGraphInfo>();
+    auto &pg_info = registered_property_graphs[property_graph_name]
+                        ->Cast<CreatePropertyGraphInfo>();
     pg_info.label_map[table->main_label] = table;
     if (!table->discriminator.empty()) {
       for (const auto &label : table->sub_labels) {
@@ -115,6 +118,5 @@ duckpgq::core::CSR *DuckPGQState::GetCSR(int32_t id) {
   }
   return csr_entry->second.get();
 }
-
 
 } // namespace duckdb

--- a/src/duckpgq_state.cpp
+++ b/src/duckpgq_state.cpp
@@ -20,6 +20,74 @@ DuckPGQState::DuckPGQState(shared_ptr<ClientContext> context) {
   if (query->HasError()) {
     throw TransactionException(query->GetError());
   }
+
+
+  RetrievePropertyGraphs(new_conn);
+}
+
+void DuckPGQState::RetrievePropertyGraphs(shared_ptr<ClientContext> context) {
+  auto retrieve_pg = context->Query("SELECT * FROM __duckpgq_internal", false);
+
+  auto &materialized_result = retrieve_pg->Cast<MaterializedQueryResult>();
+  auto row_count = materialized_result.RowCount();
+  if (row_count == 0) {
+    return; // no results
+  }
+  auto chunk = materialized_result.Fetch();
+  for (idx_t i = 0; i < row_count; i++) {
+    auto table = make_shared_ptr<PropertyGraphTable>();
+    string property_graph_name = chunk->GetValue(0, i).GetValue<string>();
+    table->table_name = chunk->GetValue(1, i).GetValue<string>();
+    table->main_label = chunk->GetValue(2, i).GetValue<string>();
+    table->is_vertex_table = chunk->GetValue(3, i).GetValue<bool>();
+    table->all_columns = true; // TODO Be stricter on properties
+    if (!table->is_vertex_table) {
+      // Handle edge table related things.
+      table->source_reference = chunk->GetValue(4, i).GetValue<string>();
+      auto source_pk_chunk = ListValue::GetChildren(chunk->GetValue(5, i));
+      for (const auto& source: source_pk_chunk) {
+        table->source_pk.push_back(source.GetValue<string>());
+      }
+      auto source_fk_chunk = ListValue::GetChildren(chunk->GetValue(6, i));
+      for (const auto& destination: source_fk_chunk) {
+        table->source_fk.push_back(destination.GetValue<string>());
+      }
+      table->destination_reference = chunk->GetValue(7, i).GetValue<string>();
+      auto destination_pk_chunk = ListValue::GetChildren(chunk->GetValue(8, i));
+
+      for (const auto& source: destination_pk_chunk) {
+        table->destination_pk.push_back(source.GetValue<string>());
+      }
+      auto destination_fk_chunk = ListValue::GetChildren(chunk->GetValue(9, i));
+      for (const auto& destination: destination_fk_chunk) {
+        table->destination_fk.push_back(destination.GetValue<string>());
+      }
+    }
+    string discriminator = chunk->GetValue(10, i).GetValue<string>();
+    if (discriminator != "NULL") {
+      table->discriminator = discriminator;
+      auto sublabels = ListValue::GetChildren(chunk->GetValue(11, i));
+      for (const auto& sublabel : sublabels) {
+        table->sub_labels.push_back(sublabel.GetValue<string>());
+      }
+    }
+
+    if (registered_property_graphs.find(property_graph_name) == registered_property_graphs.end()) {
+      registered_property_graphs[property_graph_name] = make_uniq<CreatePropertyGraphInfo>(property_graph_name);
+    }
+    auto &pg_info = registered_property_graphs[property_graph_name]->Cast<CreatePropertyGraphInfo>();
+    pg_info.label_map[table->main_label] = table;
+    if (!table->discriminator.empty()) {
+      for (const auto &label : table->sub_labels) {
+        pg_info.label_map[label] = table;
+      }
+    }
+    if (table->is_vertex_table) {
+      pg_info.vertex_tables.push_back(std::move(table));
+    } else {
+      pg_info.edge_tables.push_back(std::move(table));
+    }
+  }
 }
 
 void DuckPGQState::QueryEnd() {

--- a/src/duckpgq_state.cpp
+++ b/src/duckpgq_state.cpp
@@ -2,7 +2,25 @@
 
 namespace duckdb {
 
-DuckPGQState::DuckPGQState() = default;
+DuckPGQState::DuckPGQState(shared_ptr<ClientContext> context) {
+  auto new_conn = make_shared_ptr<ClientContext>(context->db);
+  auto query = new_conn->Query("CREATE TABLE IF NOT EXISTS __duckpgq_internal ("
+                  "property_graph varchar, "
+                  "table_name varchar, "
+                  "label varchar, "
+                  "is_vertex_table boolean, "
+                  "source_table varchar, "
+                  "source_pk varchar[], "
+                  "source_fk varchar[], "
+                  "destination_table varchar, "
+                  "destination_pk varchar[], "
+                  "destination_fk varchar[], "
+                  "discriminator varchar, "
+                  "sub_labels varchar[])", false);
+  if (query->HasError()) {
+    throw TransactionException(query->GetError());
+  }
+}
 
 void DuckPGQState::QueryEnd() {
   parse_data.reset();

--- a/src/include/duckpgq_extension.hpp
+++ b/src/include/duckpgq_extension.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "duckpgq/common.hpp"
+#include "duckdb/planner/extension_callback.hpp"
+#include <duckpgq_state.hpp>
 
 namespace duckdb {
 
@@ -8,6 +10,18 @@ class DuckpgqExtension : public Extension {
 public:
   void Load(DuckDB &db) override;
   std::string Name() override;
+};
+
+class DuckpgqLoadExtension : public ExtensionCallback {
+  void OnConnectionOpened(ClientContext &context) override {
+    auto duckpgq_state = context.registered_state->Get<DuckPGQState>("duckpgq");
+    if (duckpgq_state == nullptr) {
+      auto state = make_shared_ptr<DuckPGQState>();
+      context.registered_state->Insert("duckpgq", state);
+      std::cout << "initialized duckpgq state" << std::endl;
+    }
+
+  }
 };
 
 } // namespace duckpgq

--- a/src/include/duckpgq_extension.hpp
+++ b/src/include/duckpgq_extension.hpp
@@ -1,8 +1,6 @@
 #pragma once
 
 #include "duckpgq/common.hpp"
-#include "duckdb/planner/extension_callback.hpp"
-#include <duckpgq_state.hpp>
 
 namespace duckdb {
 
@@ -10,18 +8,6 @@ class DuckpgqExtension : public Extension {
 public:
   void Load(DuckDB &db) override;
   std::string Name() override;
-};
-
-class DuckpgqLoadExtension : public ExtensionCallback {
-  void OnConnectionOpened(ClientContext &context) override {
-    auto duckpgq_state = context.registered_state->Get<DuckPGQState>("duckpgq");
-    if (duckpgq_state == nullptr) {
-      auto state = make_shared_ptr<DuckPGQState>();
-      context.registered_state->Insert("duckpgq", state);
-      std::cout << "initialized duckpgq state" << std::endl;
-    }
-
-  }
 };
 
 } // namespace duckpgq

--- a/src/include/duckpgq_extension_callback.hpp
+++ b/src/include/duckpgq_extension_callback.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+
+#include "duckpgq/common.hpp"
+#include "duckdb/planner/extension_callback.hpp"
+#include <duckpgq_state.hpp>
+
+namespace duckdb {
+class DuckpgqExtensionCallback : public ExtensionCallback {
+  void OnConnectionOpened(ClientContext &context) override {
+    context.registered_state->Insert("duckpgq", make_shared_ptr<DuckPGQState>());
+  };
+};
+}

--- a/src/include/duckpgq_extension_callback.hpp
+++ b/src/include/duckpgq_extension_callback.hpp
@@ -8,7 +8,8 @@
 namespace duckdb {
 class DuckpgqExtensionCallback : public ExtensionCallback {
   void OnConnectionOpened(ClientContext &context) override {
-    context.registered_state->Insert("duckpgq", make_shared_ptr<DuckPGQState>());
-  };
+    context.registered_state->Insert("duckpgq",
+      make_shared_ptr<DuckPGQState>(context.shared_from_this()));
+  }
 };
 }

--- a/src/include/duckpgq_state.hpp
+++ b/src/include/duckpgq_state.hpp
@@ -8,7 +8,8 @@ namespace duckdb {
 
 class DuckPGQState : public ClientContextState {
 public:
-  explicit DuckPGQState(unique_ptr<ParserExtensionParseData> parse_data);
+  explicit DuckPGQState();
+
   void QueryEnd() override;
   CreatePropertyGraphInfo *GetPropertyGraph(const string &pg_name);
   duckpgq::core::CSR *GetCSR(int32_t id);

--- a/src/include/duckpgq_state.hpp
+++ b/src/include/duckpgq_state.hpp
@@ -14,6 +14,8 @@ public:
   CreatePropertyGraphInfo *GetPropertyGraph(const string &pg_name);
   duckpgq::core::CSR *GetCSR(int32_t id);
 
+  void RetrievePropertyGraphs(shared_ptr<ClientContext> context);
+
 public:
   unique_ptr<ParserExtensionParseData> parse_data;
 

--- a/src/include/duckpgq_state.hpp
+++ b/src/include/duckpgq_state.hpp
@@ -8,7 +8,7 @@ namespace duckdb {
 
 class DuckPGQState : public ClientContextState {
 public:
-  explicit DuckPGQState();
+  explicit DuckPGQState(shared_ptr<ClientContext> context);
 
   void QueryEnd() override;
   CreatePropertyGraphInfo *GetPropertyGraph(const string &pg_name);

--- a/test/sql/create_pg/all_properties.test
+++ b/test/sql/create_pg/all_properties.test
@@ -33,4 +33,4 @@ EDGE TABLES (
     know    SOURCE KEY ( src ) REFERENCES Student ( id )
             DESTINATION KEY ( dst ) REFERENCES Student ( id )
             LABEL Knows
-    )
+    );

--- a/test/sql/create_pg/create_pg_multiple_connections.test
+++ b/test/sql/create_pg/create_pg_multiple_connections.test
@@ -1,29 +1,26 @@
 # name: test/sql/create_pg/all_properties.test
-# description: Testing the creation of property graphs with all properties
-# group: [duckpgq_sql_create_pg]
-
-#statement ok
-#pragma enable_verification
+# description: Testing the creation of property graphs across multiple connections
+# group: [duckpgq_sql_create_pg_multiple_connections]
 
 require duckpgq
 
-statement ok
+statement ok con1
 CREATE TABLE Student(id BIGINT, name VARCHAR);
 
-statement ok
+statement ok con1
 CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);
 
-statement ok
+statement ok con1
 CREATE TABLE School(school_name VARCHAR, school_id BIGINT, school_kind BIGINT);
 
-statement ok
+statement ok con1
 INSERT INTO Student VALUES (0, 'Daniel'), (1, 'Tavneet'), (2, 'Gabor'), (3, 'Peter');
 
-statement ok
+statement ok con1
 INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (1,2, 14), (1,3, 15), (2,3, 16);
 
 # all properties
-statement ok
+statement ok con2
 -CREATE PROPERTY GRAPH pg_all_properties
 VERTEX TABLES (
     Student LABEL Person,

--- a/test/sql/create_pg/create_pg_multiple_connections.test
+++ b/test/sql/create_pg/create_pg_multiple_connections.test
@@ -20,7 +20,7 @@ statement ok con1
 INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (1,2, 14), (1,3, 15), (2,3, 16);
 
 # all properties
-statement ok con2
+statement ok con1
 -CREATE PROPERTY GRAPH pg_all_properties
 VERTEX TABLES (
     Student LABEL Person,
@@ -31,3 +31,6 @@ EDGE TABLES (
             DESTINATION KEY ( dst ) REFERENCES Student ( id )
             LABEL Knows
     )
+
+statement ok con2
+select * from local_clustering_coefficient(pg_all_properties, person, knows);

--- a/test/sql/create_pg/create_pg_multiple_connections.test
+++ b/test/sql/create_pg/create_pg_multiple_connections.test
@@ -23,7 +23,7 @@ INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (1,2, 14), (1,3, 15), (
 statement ok con1
 -CREATE PROPERTY GRAPH pg_all_properties
 VERTEX TABLES (
-    Student LABEL Person,
+    Student,
     School  LABEL School IN School_kind (Hogeschool, University)
     )
 EDGE TABLES (
@@ -33,4 +33,13 @@ EDGE TABLES (
     )
 
 statement ok con2
-select * from local_clustering_coefficient(pg_all_properties, person, knows);
+select * from local_clustering_coefficient(pg_all_properties, student, knows);
+
+statement ok con2
+-from graph_table (pg_all_properties match (a:student))
+
+statement ok con1
+-from graph_table (pg_all_properties match (a:student))
+
+statement ok con3
+-from graph_table (pg_all_properties match (a:student))

--- a/test/sql/create_pg/create_pg_multiple_connections.test
+++ b/test/sql/create_pg/create_pg_multiple_connections.test
@@ -43,3 +43,37 @@ statement ok con1
 
 statement ok con3
 -from graph_table (pg_all_properties match (a:student))
+
+statement ok con1
+-DROP PROPERTY GRAPH pg_all_properties
+
+statement error con3
+-from graph_table (pg_all_properties match (a:student))
+----
+Binder Error: Property graph pg_all_properties does not exist
+
+statement error con4
+-from graph_table (pg_all_properties match (a:student))
+----
+Binder Error: Property graph pg_all_properties does not exist
+
+statement error con2
+-from graph_table (pg_all_properties match (a:student))
+----
+Binder Error: Property graph pg_all_properties does not exist
+
+statement ok con1
+-CREATE PROPERTY GRAPH pg_all_properties
+VERTEX TABLES (
+    Student,
+    School  LABEL School IN School_kind (Hogeschool, University)
+    )
+EDGE TABLES (
+    know    SOURCE KEY ( src ) REFERENCES Student ( id )
+            DESTINATION KEY ( dst ) REFERENCES Student ( id )
+            LABEL Knows
+    )
+
+# connection 2 already exists, but pg has been dropped and recreated
+statement ok con2
+-from graph_table (pg_all_properties match (a:student))


### PR DESCRIPTION
Fixes #97 

Property graphs are now persistent rather than transient. When a connection registers a property graph, it’s stored in the __duckpgq_internal table (I’m betting people won’t use this table name, though future me might regret it!). Any new connection will automatically register all property graphs stored in __duckpgq_internal. Additionally, dropping a property graph now removes it across all connections.
