### PR TITLE
Fix incorrectly trying to use label to find source table

### DIFF
--- a/src/core/functions/table/local_clustering_coefficient.cpp
+++ b/src/core/functions/table/local_clustering_coefficient.cpp
@@ -21,12 +21,12 @@ namespace core {
 // Main binding function
 unique_ptr<TableRef> LocalClusteringCoefficientFunction::LocalClusteringCoefficientBindReplace(ClientContext &context, TableFunctionBindInput &input) {
     auto pg_name = StringUtil::Lower(StringValue::Get(input.inputs[0]));
-    auto node_table = StringUtil::Lower(StringValue::Get(input.inputs[1]));
-    auto edge_table = StringUtil::Lower(StringValue::Get(input.inputs[2]));
+    auto node_label = StringUtil::Lower(StringValue::Get(input.inputs[1]));
+    auto edge_label = StringUtil::Lower(StringValue::Get(input.inputs[2]));
 
     auto duckpgq_state = GetDuckPGQState(context);
     auto pg_info = GetPropertyGraphInfo(duckpgq_state, pg_name);
-    auto edge_pg_entry = ValidateSourceNodeAndEdgeTable(pg_info, node_table, edge_table);
+    auto edge_pg_entry = ValidateSourceNodeAndEdgeTable(pg_info, node_label, edge_label);
 
     auto select_node = CreateSelectNode(edge_pg_entry, "local_clustering_coefficient", "local_clustering_coefficient");
 

--- a/src/core/utils/duckpgq_utils.cpp
+++ b/src/core/utils/duckpgq_utils.cpp
@@ -32,17 +32,17 @@ CreatePropertyGraphInfo* GetPropertyGraphInfo(const shared_ptr<DuckPGQState> &du
 }
 
 // Function to validate the source node and edge table
-shared_ptr<PropertyGraphTable> ValidateSourceNodeAndEdgeTable(CreatePropertyGraphInfo *pg_info, const std::string &node_table, const std::string &edge_table) {
-  auto source_node_pg_entry = pg_info->GetTable(node_table, true, true);
+shared_ptr<PropertyGraphTable> ValidateSourceNodeAndEdgeTable(CreatePropertyGraphInfo *pg_info, const std::string &node_label, const std::string &edge_label) {
+  auto source_node_pg_entry = pg_info->GetTable(node_label, true, true);
   if (!source_node_pg_entry->is_vertex_table) {
-    throw Exception(ExceptionType::INVALID, node_table + " is an edge table, expected a vertex table");
+    throw Exception(ExceptionType::INVALID, node_label + " is an edge table, expected a vertex table");
   }
-  auto edge_pg_entry = pg_info->GetTable(edge_table, true, false);
+  auto edge_pg_entry = pg_info->GetTable(edge_label, true, false);
   if (edge_pg_entry->is_vertex_table) {
-    throw Exception(ExceptionType::INVALID, edge_table + " is a vertex table, expected an edge table");
+    throw Exception(ExceptionType::INVALID, edge_label + " is a vertex table, expected an edge table");
   }
-  if (!edge_pg_entry->IsSourceTable(node_table)) {
-    throw Exception(ExceptionType::INVALID, "Vertex table " + node_table + " is not a source of edge table " + edge_table);
+  if (!edge_pg_entry->IsSourceTable(source_node_pg_entry->table_name)) {
+    throw Exception(ExceptionType::INVALID, "Vertex table " + node_label + " is not a source of edge table " + edge_label);
   }
   return edge_pg_entry;
 }

--- a/test/sql/label_optional.test
+++ b/test/sql/label_optional.test
@@ -4,6 +4,43 @@
 
 require duckpgq
 
+# Test with a different number of vertices and edges
+statement ok
+CREATE TABLE VariedStudent(id BIGINT, name VARCHAR);INSERT INTO VariedStudent VALUES (0, 'Alice'), (1, 'Bob'), (2, 'Charlie'), (3, 'Dave'), (4, 'Eve'), (5, 'Frank');
+
+statement ok
+CREATE TABLE VariedKnow(src BIGINT, dst BIGINT);INSERT INTO VariedKnow VALUES (0,1), (0,2), (0,3), (1,2), (2,3), (3,4), (4,5);
+
+statement ok
+-CREATE PROPERTY GRAPH varied_pg_label_a
+VERTEX TABLES (
+    VariedStudent label a
+    )
+EDGE TABLES (
+    VariedKnow    SOURCE KEY ( src ) REFERENCES VariedStudent ( id )
+            DESTINATION KEY ( dst ) REFERENCES VariedStudent ( id )
+    );
+
+
+query II
+select id, local_clustering_coefficient from local_clustering_coefficient(varied_pg_label_a, a, variedknow);
+----
+0	0.6666667
+1	1.0
+2	0.6666667
+3	0.33333334
+4	0.0
+5	0.0
+
+statement ok
+select * from pagerank(varied_pg_label_a, a, variedknow);
+
+statement error
+select id, local_clustering_coefficient from local_clustering_coefficient(varied_pg_label_a, variedStudent, variedknow);
+----
+Invalid Error: Label 'variedstudent' not found. Did you mean the vertex label 'a'?
+
+
 statement ok
 import database 'duckdb/data/SNB0.003';
 


### PR DESCRIPTION
Fixes #154 

In the case where the label doesn't equal the table name, the graph algorithms would incorrectly throw an error that the source table was incorrect. This PR fixes the issue by first finding the associated PropertyGraphTable with the label, and then using the table name of this to check the source table reference in the edge table. 

