### PR TITLE
Allow path finding on edgeless graphs

### DIFF
--- a/src/core/functions/scalar/iterativelength.cpp
+++ b/src/core/functions/scalar/iterativelength.cpp
@@ -53,7 +53,7 @@ static void IterativeLengthFunction(DataChunk &args, ExpressionState &state,
         "Need to initialize CSR before doing shortest path");
   }
 
-  if (!(csr_entry->second->initialized_v && csr_entry->second->initialized_e)) {
+  if (!csr_entry->second->initialized_v) {
     throw ConstraintException(
         "Need to initialize CSR before doing shortest path");
   }

--- a/src/core/functions/scalar/shortest_path.cpp
+++ b/src/core/functions/scalar/shortest_path.cpp
@@ -56,12 +56,24 @@ static void ShortestPathFunction(DataChunk &args, ExpressionState &state,
   auto duckpgq_state = GetDuckPGQState(info.context);
 
   D_ASSERT(duckpgq_state->csr_list[info.csr_id]);
+  auto csr_entry = duckpgq_state->csr_list.find(info.csr_id);
+  if (csr_entry == duckpgq_state->csr_list.end()) {
+    throw ConstraintException("Invalid ID");
+  }
+  auto &csr = csr_entry->second;
+
+
+  if (!csr->initialized_v) {
+    throw ConstraintException(
+        "Need to initialize CSR before doing shortest path");
+  }
+
   int32_t id = args.data[0].GetValue(0).GetValue<int32_t>();
   int64_t v_size = args.data[1].GetValue(0).GetValue<int64_t>();
 
-  int64_t *v = (int64_t *)duckpgq_state->csr_list[id]->v;
-  vector<int64_t> &e = duckpgq_state->csr_list[id]->e;
-  vector<int64_t> &edge_ids = duckpgq_state->csr_list[id]->edge_ids;
+  auto *v = (int64_t *)csr->v;
+  vector<int64_t> &e = csr->e;
+  vector<int64_t> &edge_ids = csr->edge_ids;
 
   auto &src = args.data[2];
   auto &target = args.data[3];

--- a/test/sql/path_finding/edgeless_graph.test
+++ b/test/sql/path_finding/edgeless_graph.test
@@ -21,8 +21,12 @@ statement ok
   		  LABEL E
 );
 
-statement ok
+query II
 -FROM GRAPH_TABLE(testgraph
       MATCH p = ANY SHORTEST (n1:N)-[e:E]-> * (n2:N)
-      COLUMNS (edges(p) AS path_edges)
+      COLUMNS (n1.id, edges(p) AS path_edges)
 );
+----
+1	[]
+2	[]
+3	[]

--- a/test/sql/path_finding/edgeless_graph.test
+++ b/test/sql/path_finding/edgeless_graph.test
@@ -21,12 +21,9 @@ statement ok
   		  LABEL E
 );
 
-query II
+query IIIII
 -FROM GRAPH_TABLE(testgraph
       MATCH p = ANY SHORTEST (n1:N)-[e:E]-> * (n2:N)
-      COLUMNS (n1.id, edges(p) AS path_edges)
+      COLUMNS (n1.id, n2.id, element_id(p), edges(p) AS path_edges, path_length(p))
 );
 ----
-1	[]
-2	[]
-3	[]

--- a/test/sql/path_finding/edgeless_graph.test
+++ b/test/sql/path_finding/edgeless_graph.test
@@ -27,3 +27,6 @@ query IIIII
       COLUMNS (n1.id, n2.id, element_id(p), edges(p) AS path_edges, path_length(p))
 );
 ----
+1	1	[0]	[]	0
+2	2	[1]	[]	0
+3	3	[2]	[]	0

--- a/test/sql/path_finding/edgeless_graph.test
+++ b/test/sql/path_finding/edgeless_graph.test
@@ -1,0 +1,28 @@
+
+require duckpgq
+
+statement ok
+CREATE TABLE nodes (id INTEGER);
+
+statement ok
+CREATE TABLE edges (src INTEGER, dst INTEGER);
+
+statement ok
+INSERT INTO nodes VALUES (1), (2), (3);
+
+statement ok
+-CREATE PROPERTY GRAPH testgraph
+  	VERTEX TABLES (
+	    nodes LABEL N
+	)
+	EDGE TABLES (
+  	    edges SOURCE KEY (src) REFERENCES nodes (id)
+        	  DESTINATION KEY (dst) REFERENCES nodes (id)
+  		  LABEL E
+);
+
+statement ok
+-FROM GRAPH_TABLE(testgraph
+      MATCH p = ANY SHORTEST (n1:N)-[e:E]-> * (n2:N)
+      COLUMNS (edges(p) AS path_edges)
+);


### PR DESCRIPTION
Fixes #163 

With an edgeless graph, we don't "initialize" the edge array in the CSR, because there is nothing to initialize. This caused an error to be thrown when doing the path-finding UDFs but that error was unnecessary. 
This PR allows the path-finding to be done on the edgeless graph.