### PR TITLE
Add some missing error handling for attached databases

### DIFF
--- a/src/core/functions/table/create_property_graph.cpp
+++ b/src/core/functions/table/create_property_graph.cpp
@@ -178,7 +178,7 @@ unique_ptr<FunctionData> CreatePropertyGraphFunction::CreatePropertyGraphBind(
 
         if (!table) {
           throw Exception(ExceptionType::INVALID,
-                          "Table " + vertex_table->schema_name + "." + vertex_table->table_name + " not found");
+                          "Table " + vertex_table->catalog_name + "." + vertex_table->table_name + " not found");
         }
 
         CheckPropertyGraphTableColumns(vertex_table, *table);
@@ -190,6 +190,8 @@ unique_ptr<FunctionData> CreatePropertyGraphFunction::CreatePropertyGraphBind(
           throw Exception(ExceptionType::INVALID, "Found a view with name " + vertex_table->table_name + ". Creating property graph tables over views is currently not supported.");
         }
         throw Exception(ExceptionType::INVALID, e.what());
+      } catch (BinderException &e) {
+        throw Exception(ExceptionType::INVALID, "Catalog '" + vertex_table->catalog_name + "' does not exist!");
       }
 
 
@@ -207,7 +209,7 @@ unique_ptr<FunctionData> CreatePropertyGraphFunction::CreatePropertyGraphBind(
                                                       edge_table->table_name, OnEntryNotFound::RETURN_NULL);
       if (!table) {
         throw Exception(ExceptionType::INVALID,
-                        "Table " + edge_table->schema_name + "." + edge_table->table_name + " not found");
+                        "Table " + edge_table->catalog_name + "." + edge_table->table_name + " not found");
       }
 
       CheckPropertyGraphTableColumns(edge_table, *table);
@@ -246,6 +248,8 @@ unique_ptr<FunctionData> CreatePropertyGraphFunction::CreatePropertyGraphBind(
         throw Exception(ExceptionType::INVALID, "Found a view with name " + edge_table->table_name + ". Creating property graph tables over views is currently not supported.");
       }
       throw Exception(ExceptionType::INVALID, e.what());
+    } catch (BinderException &e) {
+      throw Exception(ExceptionType::INVALID, "Catalog '" + edge_table->catalog_name + "' does not exist!");
     }
   }
   return make_uniq<CreatePropertyGraphBindData>(info);

--- a/src/core/functions/table/create_property_graph.cpp
+++ b/src/core/functions/table/create_property_graph.cpp
@@ -178,7 +178,7 @@ unique_ptr<FunctionData> CreatePropertyGraphFunction::CreatePropertyGraphBind(
 
         if (!table) {
           throw Exception(ExceptionType::INVALID,
-                          "Table " + vertex_table->catalog_name + "." + vertex_table->table_name + " not found");
+                          "Table " + (vertex_table->catalog_name.empty() ? DEFAULT_SCHEMA : vertex_table->catalog_name) + "." + vertex_table->table_name + " not found");
         }
 
         CheckPropertyGraphTableColumns(vertex_table, *table);
@@ -209,7 +209,7 @@ unique_ptr<FunctionData> CreatePropertyGraphFunction::CreatePropertyGraphBind(
                                                       edge_table->table_name, OnEntryNotFound::RETURN_NULL);
       if (!table) {
         throw Exception(ExceptionType::INVALID,
-                        "Table " + edge_table->catalog_name + "." + edge_table->table_name + " not found");
+                        "Table " + (edge_table->catalog_name.empty() ? DEFAULT_SCHEMA : edge_table->catalog_name) + "." + edge_table->table_name + " not found");
       }
 
       CheckPropertyGraphTableColumns(edge_table, *table);

--- a/test/sql/create_pg/attach_pg.test
+++ b/test/sql/create_pg/attach_pg.test
@@ -12,6 +12,22 @@ select count(*) from bluesky.follows;
 ----
 19566
 
+statement error
+-create or replace property graph stations vertex tables (stations.stations)
+----
+Invalid Error: Catalog 'stations' does not exist!
+
+statement error
+-create or replace property graph stations vertex tables (bluesky.account)
+    edge tables (nonexistingcatalog.follows source key (source) references bluesky.account (did)
+        destination key (destination) references bluesky.account (did))
+----
+Invalid Error: Catalog 'nonexistingcatalog' does not exist!
+
+statement error
+-create or replace property graph stations vertex tables (bluesky.tabledoesnotexist)
+----
+Invalid Error: Table bluesky.tabledoesnotexist not found
 
 statement ok con1
 -CREATE OR REPLACE PROPERTY GRAPH bluesky


### PR DESCRIPTION
Previously, it was possible to get a segmentation fault if the catalog that you tried to create a property graph over did not exist. This PR should fix that. 

Also fixes some incorrect usage of schema_name, using catalog_name now instead