### PR TITLE
Fix compilation via move

### DIFF
--- a/src/core/functions/function_data/pagerank_function_data.cpp
+++ b/src/core/functions/function_data/pagerank_function_data.cpp
@@ -35,7 +35,7 @@ unique_ptr<FunctionData> PageRankFunctionData::Copy() const {
   result->state_initialized = state_initialized;
   result->converged = converged;
   // Note: state_lock is not copied as mutexes are not copyable
-  return result;
+  return std::move(result);
 }
 
 // Equals method

--- a/src/core/functions/function_data/weakly_connected_component_function_data.cpp
+++ b/src/core/functions/function_data/weakly_connected_component_function_data.cpp
@@ -30,7 +30,7 @@ unique_ptr<FunctionData> WeaklyConnectedComponentFunctionData::WeaklyConnectedCo
 unique_ptr<FunctionData> WeaklyConnectedComponentFunctionData::Copy() const {
   auto result =  make_uniq<WeaklyConnectedComponentFunctionData>(context, csr_id, componentId);
   result->component_id_initialized = component_id_initialized;
-  return result;
+  return std::move(result);
 
 }
 bool WeaklyConnectedComponentFunctionData::Equals(const FunctionData &other_p) const {

--- a/src/core/functions/table/match.cpp
+++ b/src/core/functions/table/match.cpp
@@ -620,7 +620,7 @@ unique_ptr<ParsedExpression> PGQMatchFunction::AddPathQuantifierCondition(
   auto between_expression = make_uniq<BetweenExpression>(
       std::move(addition_function), std::move(lower_limit),
       std::move(upper_limit));
-  return between_expression;
+  return std::move(between_expression);
 }
 
 void PGQMatchFunction::AddPathFinding(


### PR DESCRIPTION
I met a few compilation failures, for example:
```
/home/ubuntu/duckpgq-extension/src/core/functions/function_data/weakly_connected_component_function_data.cpp:33:10: error: could not convert 'result' from 'unique_ptr<duckpgq::core::WeaklyConnectedComponentFunctionData,default_delete<duckpgq::core::WeaklyConnectedComponentFunctionData>,[...]>' to 'unique_ptr<duckdb::FunctionData,default_delete<duckdb::FunctionData>,[...]>'
   33 |   return result;
      |          ^~~~~~
      |          |
      |          unique_ptr<duckpgq::core::WeaklyConnectedComponentFunctionData,default_delete<duckpgq::core::WeaklyConnectedComponentFunctionData>,[...]>
```
Similar to the issue raised in pg_duckdb: https://github.com/duckdb/pg_duckdb/discussions/455