### PR TITLE
[easy] Address some compilation warnings

### DIFF
--- a/src/core/functions/scalar/local_clustering_coefficient.cpp
+++ b/src/core/functions/scalar/local_clustering_coefficient.cpp
@@ -42,7 +42,7 @@ static void LocalClusteringCoefficientFunction(DataChunk &args,
 
   DuckPGQBitmap neighbors(v_size);
 
-  for (int32_t n = 0; n < args.size(); n++) {
+  for (idx_t n = 0; n < args.size(); n++) {
     auto src_sel = vdata_src.sel->get_index(n);
     if (!vdata_src.validity.RowIsValid(src_sel)) {
       result_validity.SetInvalid(n);
@@ -54,15 +54,15 @@ static void LocalClusteringCoefficientFunction(DataChunk &args,
       continue;
     }
     neighbors.reset();
-    for (size_t offset = v[src_node]; offset < v[src_node + 1]; offset++) {
+    for (int64_t offset = v[src_node]; offset < v[src_node + 1]; offset++) {
       neighbors.set(e[offset]);
     }
 
     // Count connections between neighbors
     int64_t count = 0;
-    for (size_t offset = v[src_node]; offset < v[src_node + 1]; offset++) {
+    for (int64_t offset = v[src_node]; offset < v[src_node + 1]; offset++) {
       int64_t neighbor = e[offset];
-      for (size_t offset2 = v[neighbor]; offset2 < v[neighbor + 1]; offset2++) {
+      for (int64_t offset2 = v[neighbor]; offset2 < v[neighbor + 1]; offset2++) {
         int is_connected = neighbors.test(e[offset2]);
         count += is_connected; // Add 1 if connected, 0 otherwise
       }

--- a/src/core/functions/scalar/weakly_connected_component.cpp
+++ b/src/core/functions/scalar/weakly_connected_component.cpp
@@ -101,7 +101,7 @@ static void WeaklyConnectedComponentFunction(DataChunk &args,
   idx_t started_searches = 0;
   while (started_searches < args.size()) {
     // empty visit vectors
-    for (auto i = 0; i < v_size; i++) {
+    for (size_t i = 0; i < v_size; i++) {
       seen[i] = 0;
       visit1[i] = 0;
     }
@@ -146,7 +146,7 @@ static void WeaklyConnectedComponentFunction(DataChunk &args,
           continue;
         }
         // Update component IDs
-        for (int64_t i = 0; i < v_size; i++) {
+        for (size_t i = 0; i < v_size; i++) {
           if (seen[i][lane]) {
             UpdateComponentId(i, src_data[search_num], info);
           }

--- a/src/core/parser/duckpgq_parser.cpp
+++ b/src/core/parser/duckpgq_parser.cpp
@@ -22,7 +22,6 @@ namespace core {
 
 ParserExtensionParseResult duckpgq_parse(ParserExtensionInfo *info,
                                          const std::string &query) {
-  auto parse_info = (DuckPGQParserExtensionInfo &)(info);
   Parser parser;
   parser.ParseQuery((query[0] == '-') ? query.substr(1, query.length())
                                       : query);


### PR DESCRIPTION
Met some warnings during compilation, this PR fix them all.
Most of the warning here are caused by comparison between signed and unsigned integers.