### PR TITLE
Include more information in describe property graph

### DIFF
--- a/src/core/functions/table/describe_property_graph.cpp
+++ b/src/core/functions/table/describe_property_graph.cpp
@@ -37,7 +37,8 @@ DescribePropertyGraphFunction::DescribePropertyGraphBind(
   }
   auto property_graph =
       dynamic_cast<CreatePropertyGraphInfo *>(pg_table->second.get());
-
+  names.emplace_back("property_graph");
+  return_types.emplace_back(LogicalType::VARCHAR);
   names.emplace_back("table_name");
   return_types.emplace_back(LogicalType::VARCHAR);
   names.emplace_back("label");
@@ -60,6 +61,10 @@ DescribePropertyGraphFunction::DescribePropertyGraphBind(
   return_types.emplace_back(LogicalType::VARCHAR);
   names.emplace_back("sub_labels");
   return_types.emplace_back(LogicalType::LIST(LogicalType::VARCHAR));
+  names.emplace_back("catalog");
+  return_types.emplace_back(LogicalType::VARCHAR);
+  names.emplace_back("schema");
+  return_types.emplace_back(LogicalType::VARCHAR);
 
   return make_uniq<DescribePropertyGraphBindData>(property_graph);
 }
@@ -80,71 +85,84 @@ void DescribePropertyGraphFunction::DescribePropertyGraphFunc(
   auto pg_info = bind_data.describe_pg_info;
   idx_t vector_idx = 0;
   for (const auto &vertex_table : pg_info->vertex_tables) {
-    output.SetValue(0, vector_idx, Value(vertex_table->table_name));
-    output.SetValue(1, vector_idx, Value(vertex_table->main_label));
-    output.SetValue(2, vector_idx, Value(vertex_table->is_vertex_table));
-    output.SetValue(3, vector_idx, Value());
+    output.SetValue(0, vector_idx, Value(pg_info->property_graph_name));
+    output.SetValue(1, vector_idx, Value(vertex_table->table_name));
+    output.SetValue(2, vector_idx, Value(vertex_table->main_label));
+    output.SetValue(3, vector_idx, Value(vertex_table->is_vertex_table));
     output.SetValue(4, vector_idx, Value());
     output.SetValue(5, vector_idx, Value());
     output.SetValue(6, vector_idx, Value());
     output.SetValue(7, vector_idx, Value());
     output.SetValue(8, vector_idx, Value());
+    output.SetValue(9, vector_idx, Value());
     if (!vertex_table->discriminator.empty()) {
-      output.SetValue(9, vector_idx, Value(vertex_table->discriminator));
+      output.SetValue(10, vector_idx, Value(vertex_table->discriminator));
       vector<Value> sub_labels;
       for (const auto &label : vertex_table->sub_labels) {
         sub_labels.push_back(Value(label));
       }
-      output.SetValue(10, vector_idx,
+      output.SetValue(11, vector_idx,
                       Value::LIST(LogicalType::VARCHAR, sub_labels));
     } else {
-      output.SetValue(9, vector_idx, Value());
       output.SetValue(10, vector_idx, Value());
+      output.SetValue(11, vector_idx, Value());
     }
+    if (vertex_table->catalog_name.empty()) {
+      output.SetValue(12, vector_idx, Value());
+    } else {
+      output.SetValue(12, vector_idx, Value(vertex_table->catalog_name));
+    }
+    output.SetValue(13, vector_idx, Value(vertex_table->schema_name));
     vector_idx++;
   }
   for (const auto &edge_table : pg_info->edge_tables) {
-    output.SetValue(0, vector_idx, Value(edge_table->table_name));
-    output.SetValue(1, vector_idx, Value(edge_table->main_label));
-    output.SetValue(2, vector_idx, Value(edge_table->is_vertex_table));
-    output.SetValue(3, vector_idx, Value(edge_table->source_reference));
+    output.SetValue(0, vector_idx, Value(pg_info->property_graph_name));
+    output.SetValue(1, vector_idx, Value(edge_table->table_name));
+    output.SetValue(2, vector_idx, Value(edge_table->main_label));
+    output.SetValue(3, vector_idx, Value(edge_table->is_vertex_table));
+    output.SetValue(4, vector_idx, Value(edge_table->source_reference));
     vector<Value> source_pk_list;
     for (const auto &col : edge_table->source_pk) {
       source_pk_list.push_back(Value(col));
     }
-    output.SetValue(4, vector_idx,
+    output.SetValue(5, vector_idx,
                     Value::LIST(LogicalType::VARCHAR, source_pk_list));
     vector<Value> source_fk_list;
     for (const auto &col : edge_table->source_fk) {
       source_fk_list.push_back(Value(col));
     }
-    output.SetValue(5, vector_idx,
+    output.SetValue(6, vector_idx,
                     Value::LIST(LogicalType::VARCHAR, source_fk_list));
-    output.SetValue(6, vector_idx, Value(edge_table->destination_reference));
+    output.SetValue(7, vector_idx, Value(edge_table->destination_reference));
     vector<Value> destination_pk_list;
     for (const auto &col : edge_table->destination_pk) {
       destination_pk_list.push_back(Value(col));
     }
-    output.SetValue(7, vector_idx,
+    output.SetValue(8, vector_idx,
                     Value::LIST(LogicalType::VARCHAR, destination_pk_list));
     vector<Value> destination_fk_list;
     for (const auto &col : edge_table->destination_fk) {
       destination_fk_list.push_back(Value(col));
     }
-    output.SetValue(8, vector_idx,
+    output.SetValue(9, vector_idx,
                     Value::LIST(LogicalType::VARCHAR, destination_fk_list));
     if (!edge_table->discriminator.empty()) {
-      output.SetValue(9, vector_idx, Value(edge_table->discriminator));
+      output.SetValue(10, vector_idx, Value(edge_table->discriminator));
       vector<Value> sub_labels;
       for (const auto &label : edge_table->sub_labels) {
         sub_labels.push_back(Value(label));
       }
-      output.SetValue(10, vector_idx,
+      output.SetValue(11, vector_idx,
                       Value::LIST(LogicalType::VARCHAR, sub_labels));
     } else {
-      output.SetValue(9, vector_idx, Value());
       output.SetValue(10, vector_idx, Value());
+      output.SetValue(11, vector_idx, Value());
     }
+    if (edge_table->catalog_name.empty()) {
+      output.SetValue(12, vector_idx, Value());
+    } else {
+      output.SetValue(12, vector_idx, Value(edge_table->catalog_name));
+    }    output.SetValue(13, vector_idx, Value(edge_table->schema_name));
     vector_idx++;
   }
   output.SetCardinality(vector_idx);

--- a/src/duckpgq_state.cpp
+++ b/src/duckpgq_state.cpp
@@ -75,8 +75,13 @@ void DuckPGQState::ProcessPropertyGraphs(
     }
 
     // Extract catalog and schema names
-    table->catalog_name = chunk->GetValue(12, i).GetValue<string>();
-    table->schema_name = chunk->GetValue(13, i).GetValue<string>();
+    if (chunk->ColumnCount() == 14) {
+      table->catalog_name = chunk->GetValue(12, i).GetValue<string>();
+      table->schema_name = chunk->GetValue(13, i).GetValue<string>();
+    } else {
+      table->catalog_name = "";
+      table->schema_name = DEFAULT_SCHEMA;
+    }
 
     // Additional edge-specific handling
     if (!is_vertex) {

--- a/test/sql/create_pg/describe_pg.test
+++ b/test/sql/create_pg/describe_pg.test
@@ -18,11 +18,11 @@ EDGE TABLES (
                             LABEL Knows
     );
 
-query IIIIIIIIIII
+query IIIIIIIIIIIIII
 -DESCRIBE PROPERTY GRAPH snb;
 ----
-Person	person	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
-Person_knows_person	knows	false	Person	[id]	[Person1Id]	Person	[id]	[Person2Id]	NULL	NULL
+snb	Person	person	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
+snb	Person_knows_person	knows	false	Person	[id]	[Person1Id]	Person	[id]	[Person2Id]	NULL	NULL	NULL	main
 
 statement ok
 -CREATE OR REPLACE PROPERTY GRAPH snb
@@ -67,29 +67,46 @@ EDGE TABLES (
                             LABEL replyOf
     );
 
-query IIIIIIIIIII
+query IIIIIIIIIIIIII
 -DESCRIBE PROPERTY GRAPH snb;
 ----
-Message	message	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
-City	city	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
-Country	country	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
-TagClass	tagclass	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
-Tag	tag	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
-Place	place	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
-Organisation	organisation	true	NULL	NULL	NULL	NULL	NULL	NULL	typemask	[company, university]
-Forum	forum	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
-Person	person	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
-Message_replyOf_Message	replyof	false	Message	[id]	[messageId]	Message	[id]	[ParentMessageId]	NULL	NULL
-Message_hasAuthor_Person	hasauthor	false	Message	[id]	[messageId]	Person	[id]	[PersonId]	NULL	NULL
-Message_hasTag_Tag	message_hastag	false	Message	[id]	[id]	Tag	[id]	[TagId]	NULL	NULL
-Person_likes_Message	likes_message	false	Person	[id]	[PersonId]	Message	[id]	[id]	NULL	NULL
-person_workAt_Organisation	workat_organisation	false	Person	[id]	[PersonId]	Organisation	[id]	[OrganisationId]	NULL	NULL
-Person_hasInterest_Tag	hasinterest	false	Person	[id]	[PersonId]	Tag	[id]	[TagId]	NULL	NULL
-Forum_hasTag_Tag	forum_hastag	false	Forum	[id]	[ForumId]	Tag	[id]	[TagId]	NULL	NULL
-Forum_hasMember_Person	hasmember	false	Forum	[id]	[ForumId]	Person	[id]	[PersonId]	NULL	NULL
-Person_knows_person	knows	false	Person	[id]	[Person1Id]	Person	[id]	[Person2Id]	NULL	NULL
+snb	Message	message	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
+snb	City	city	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
+snb	Country	country	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
+snb	TagClass	tagclass	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
+snb	Tag	tag	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
+snb	Place	place	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
+snb	Organisation	organisation	true	NULL	NULL	NULL	NULL	NULL	NULL	typemask	[company, university]	NULL	main
+snb	Forum	forum	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
+snb	Person	person	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
+snb	Message_replyOf_Message	replyof	false	Message	[id]	[messageId]	Message	[id]	[ParentMessageId]	NULL	NULL	NULL	main
+snb	Message_hasAuthor_Person	hasauthor	false	Message	[id]	[messageId]	Person	[id]	[PersonId]	NULL	NULL	NULL	main
+snb	Message_hasTag_Tag	message_hastag	false	Message	[id]	[id]	Tag	[id]	[TagId]	NULL	NULL	NULL	main
+snb	Person_likes_Message	likes_message	false	Person	[id]	[PersonId]	Message	[id]	[id]	NULL	NULL	NULL	main
+snb	person_workAt_Organisation	workat_organisation	false	Person	[id]	[PersonId]	Organisation	[id]	[OrganisationId]	NULL	NULL	NULL	main
+snb	Person_hasInterest_Tag	hasinterest	false	Person	[id]	[PersonId]	Tag	[id]	[TagId]	NULL	NULL	NULL	main
+snb	Forum_hasTag_Tag	forum_hastag	false	Forum	[id]	[ForumId]	Tag	[id]	[TagId]	NULL	NULL	NULL	main
+snb	Forum_hasMember_Person	hasmember	false	Forum	[id]	[ForumId]	Person	[id]	[PersonId]	NULL	NULL	NULL	main
+snb	Person_knows_person	knows	false	Person	[id]	[Person1Id]	Person	[id]	[Person2Id]	NULL	NULL	NULL	main
 
 statement error
 -DESCRIBE PROPERTY GRAPH pgdoesnotexist;
 ----
 Invalid Error: Property graph pgdoesnotexist does not exist.
+
+
+statement ok con1
+attach 'duckdb/data/bluesky/bluesky.duckdb';
+
+statement ok
+-CREATE OR REPLACE PROPERTY GRAPH bluesky
+            VERTEX TABLES (bluesky.account LABEL account)
+            EDGE TABLES (bluesky.follows    SOURCE KEY (source) REFERENCES bluesky.account (did)
+                                            DESTINATION KEY (destination) REFERENCES bluesky.account (did)
+            LABEL follows);
+
+query IIIIIIIIIIIIII
+-DESCRIBE PROPERTY GRAPH bluesky;
+----
+bluesky	account	account	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	bluesky	main
+bluesky	follows	follows	false	account	[did]	[source]	account	[did]	[destination]	NULL	NULL	bluesky	main


### PR DESCRIPTION
This PR adds three columns to the output of `DESCRIBE PROPERTY GRAPH pg`
- Property graph name
- Catalog
- Schema

Also adds a small bit of error handling. Older versions of `__duckpgq_internal` table didn't have the `catalog` and `schema` columns. Trying to import those with the updated schema caused an `InternalException`, which has been fixed. 

