### PR TITLE
Add pragma show_property_graphs

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(functions)
 add_subdirectory(operator)
 add_subdirectory(parser)
+add_subdirectory(pragma)
 add_subdirectory(utils)
 
 set(EXTENSION_SOURCES

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -1,10 +1,11 @@
 
 #include "duckpgq/core/module.hpp"
 #include "duckpgq/common.hpp"
-#include "duckpgq/core/functions/table.hpp"
 #include "duckpgq/core/functions/scalar.hpp"
-#include "duckpgq/core/parser/duckpgq_parser.hpp"
+#include "duckpgq/core/functions/table.hpp"
 #include "duckpgq/core/operator/duckpgq_operator.hpp"
+#include "duckpgq/core/parser/duckpgq_parser.hpp"
+#include "duckpgq/core/pragma/duckpgq_pragma.hpp"
 
 namespace duckpgq {
 
@@ -14,6 +15,7 @@ void CoreModule::Register(DatabaseInstance &db) {
   CoreTableFunctions::Register(db);
   CoreScalarFunctions::Register(db);
   CorePGQParser::Register(db);
+  CorePGQPragma::Register(db);
   CorePGQOperator::Register(db);
 }
 

--- a/src/core/pragma/CMakeLists.txt
+++ b/src/core/pragma/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(EXTENSION_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/show_property_graphs.cpp
+        ${EXTENSION_SOURCES}
+        PARENT_SCOPE
+)

--- a/src/core/pragma/show_property_graphs.cpp
+++ b/src/core/pragma/show_property_graphs.cpp
@@ -1,0 +1,27 @@
+#include "duckdb/function/pragma_function.hpp"
+#include "duckdb/main/extension_util.hpp"
+#include <duckpgq/core/pragma/duckpgq_pragma.hpp>
+
+namespace duckpgq {
+
+namespace core {
+
+static string PragmaShowPropertyGraphs(ClientContext &context, const FunctionParameters &parameters) {
+  return "SELECT DISTINCT property_graph from __duckpgq_internal";
+}
+
+void CorePGQPragma::RegisterShowPropertyGraphs(DatabaseInstance &instance) {
+  // Define the pragma function
+  auto pragma_func = PragmaFunction::PragmaCall(
+                  "show_property_graphs",                 // Name of the pragma
+                  PragmaShowPropertyGraphs,         // Query substitution function
+                  {}           // Parameter types (mail_limit is an integer)
+  );
+
+  // Register the pragma function
+  ExtensionUtil::RegisterFunction(instance, pragma_func);
+}
+
+} // namespace core
+
+} // namespace duckpgq

--- a/src/include/duckpgq/core/pragma/duckpgq_pragma.hpp
+++ b/src/include/duckpgq/core/pragma/duckpgq_pragma.hpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckpgq/include/core/pragma/show_property_graphs.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+#include "duckpgq/common.hpp"
+
+namespace duckpgq {
+
+namespace core {
+
+//! Class to register the PRAGMA create_inbox function
+class CorePGQPragma {
+public:
+  //! Register the PRAGMA function
+  static void Register(DatabaseInstance &instance) {
+    RegisterShowPropertyGraphs(instance);
+  }
+
+private:
+  static void RegisterShowPropertyGraphs(DatabaseInstance &instance);
+
+};
+
+
+
+} // namespace core
+
+} // namespace duckpgq

--- a/test/sql/pragma/show_property_graphs.test
+++ b/test/sql/pragma/show_property_graphs.test
@@ -1,0 +1,61 @@
+
+require duckpgq
+
+statement ok
+import database 'duckdb/data/SNB0.003';
+
+statement ok
+-CREATE PROPERTY GRAPH snb
+VERTEX TABLES (
+    Person LABEL Person,
+    Forum LABEL Forum,
+    Organisation LABEL Organisation IN typemask(company, university),
+    Place LABEL Place,
+    Tag LABEL Tag,
+    TagClass LABEL TagClass,
+    Country LABEL Country,
+    City LABEL City,
+    Message LABEL Message
+    )
+EDGE TABLES (
+    Person_knows_person     SOURCE KEY (Person1Id) REFERENCES Person (id)
+                            DESTINATION KEY (Person2Id) REFERENCES Person (id)
+                            LABEL Knows,
+    Forum_hasMember_Person  SOURCE KEY (ForumId) REFERENCES Forum (id)
+                            DESTINATION KEY (PersonId) REFERENCES Person (id)
+                            LABEL hasMember,
+    Forum_hasTag_Tag        SOURCE KEY (ForumId) REFERENCES Forum (id)
+                            DESTINATION KEY (TagId) REFERENCES Tag (id)
+                            LABEL Forum_hasTag,
+    Person_hasInterest_Tag  SOURCE KEY (PersonId) REFERENCES Person (id)
+                            DESTINATION KEY (TagId) REFERENCES Tag (id)
+                            LABEL hasInterest,
+    person_workAt_Organisation SOURCE KEY (PersonId) REFERENCES Person (id)
+                               DESTINATION KEY (OrganisationId) REFERENCES Organisation (id)
+                               LABEL workAt_Organisation,
+    Person_likes_Message    SOURCE KEY (PersonId) REFERENCES Person (id)
+                            DESTINATION KEY (id) REFERENCES Message (id)
+                            LABEL likes_Message,
+    Message_hasTag_Tag      SOURCE KEY (id) REFERENCES Message (id)
+                            DESTINATION KEY (TagId) REFERENCES Tag (id)
+                            LABEL message_hasTag,
+    Message_hasAuthor_Person    SOURCE KEY (messageId) REFERENCES Message (id)
+                                DESTINATION KEY (PersonId) REFERENCES Person (id)
+                                LABEL hasAuthor,
+    Message_replyOf_Message SOURCE KEY (messageId) REFERENCES Message (id)
+                            DESTINATION KEY (ParentMessageId) REFERENCES Message (id)
+                            LABEL replyOf
+    );
+
+query I
+pragma show_property_graphs;
+----
+snb
+
+statement ok
+-drop property graph snb;
+
+query I
+pragma show_property_graphs;
+----
+


### PR DESCRIPTION
This PR introduces the first pragma to the extension: 
`pragma show_property_graphs` which executes the query: `select distinct property_graph from __duckpgq_internal`. It returns all the registered property graphs in the table. Similar to `show tables`