### PR TITLE
Fix property graph case-sentisitivity

### DIFF
--- a/src/core/functions/scalar/local_clustering_coefficient.cpp
+++ b/src/core/functions/scalar/local_clustering_coefficient.cpp
@@ -62,7 +62,8 @@ static void LocalClusteringCoefficientFunction(DataChunk &args,
     int64_t count = 0;
     for (int64_t offset = v[src_node]; offset < v[src_node + 1]; offset++) {
       int64_t neighbor = e[offset];
-      for (int64_t offset2 = v[neighbor]; offset2 < v[neighbor + 1]; offset2++) {
+      for (int64_t offset2 = v[neighbor]; offset2 < v[neighbor + 1];
+           offset2++) {
         int is_connected = neighbors.test(e[offset2]);
         count += is_connected; // Add 1 if connected, 0 otherwise
       }

--- a/src/core/functions/table/describe_property_graph.cpp
+++ b/src/core/functions/table/describe_property_graph.cpp
@@ -162,7 +162,8 @@ void DescribePropertyGraphFunction::DescribePropertyGraphFunc(
       output.SetValue(12, vector_idx, Value());
     } else {
       output.SetValue(12, vector_idx, Value(edge_table->catalog_name));
-    }    output.SetValue(13, vector_idx, Value(edge_table->schema_name));
+    }
+    output.SetValue(13, vector_idx, Value(edge_table->schema_name));
     vector_idx++;
   }
   output.SetCardinality(vector_idx);

--- a/src/core/pragma/show_property_graphs.cpp
+++ b/src/core/pragma/show_property_graphs.cpp
@@ -6,16 +6,17 @@ namespace duckpgq {
 
 namespace core {
 
-static string PragmaShowPropertyGraphs(ClientContext &context, const FunctionParameters &parameters) {
+static string PragmaShowPropertyGraphs(ClientContext &context,
+                                       const FunctionParameters &parameters) {
   return "SELECT DISTINCT property_graph from __duckpgq_internal";
 }
 
 void CorePGQPragma::RegisterShowPropertyGraphs(DatabaseInstance &instance) {
   // Define the pragma function
   auto pragma_func = PragmaFunction::PragmaCall(
-                  "show_property_graphs",                 // Name of the pragma
-                  PragmaShowPropertyGraphs,         // Query substitution function
-                  {}           // Parameter types (mail_limit is an integer)
+      "show_property_graphs",   // Name of the pragma
+      PragmaShowPropertyGraphs, // Query substitution function
+      {}                        // Parameter types (mail_limit is an integer)
   );
 
   // Register the pragma function

--- a/src/duckpgq_state.cpp
+++ b/src/duckpgq_state.cpp
@@ -107,6 +107,7 @@ void DuckPGQState::PopulateEdgeSpecificFields(unique_ptr<DataChunk> &chunk,
 void DuckPGQState::ExtractListValues(const Value &list_value,
                                      vector<string> &output) {
   auto children = ListValue::GetChildren(list_value);
+  output.reserve(output.size() + children.size());
   for (const auto &child : children) {
     output.push_back(child.GetValue<string>());
   }

--- a/src/include/duckpgq/core/pragma/duckpgq_pragma.hpp
+++ b/src/include/duckpgq/core/pragma/duckpgq_pragma.hpp
@@ -22,10 +22,7 @@ public:
 
 private:
   static void RegisterShowPropertyGraphs(DatabaseInstance &instance);
-
 };
-
-
 
 } // namespace core
 

--- a/src/include/duckpgq_state.hpp
+++ b/src/include/duckpgq_state.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckpgq/common.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
 
 #include <duckpgq/core/utils/compressed_sparse_row.hpp>
 
@@ -33,7 +34,7 @@ public:
   // unnamed graph tables
 
   //! Property graphs that are registered
-  std::unordered_map<string, unique_ptr<CreateInfo>> registered_property_graphs;
+  case_insensitive_map_t<unique_ptr<CreateInfo>> registered_property_graphs;
 
   //! Used to build the CSR data structures required for path-finding queries
   std::unordered_map<int32_t, unique_ptr<duckpgq::core::CSR>> csr_list;

--- a/test/sql/create_pg/create_property_graph.test
+++ b/test/sql/create_pg/create_property_graph.test
@@ -51,6 +51,13 @@ EDGE TABLES (
             PROPERTIES ( createDate ) LABEL Knows
     )
 
+statement ok
+-SELECT count(id)
+FROM
+  GRAPH_TABLE (PG 
+    MATCH p = (s1:Person)-[k:Knows]->(s2:Person WHERE s2.name='Daniel') 
+    COLUMNS (s1.id));
+
 # Error as property graph pg already exists
 statement error
 -CREATE PROPERTY GRAPH pg

--- a/test/sql/create_pg/create_property_graph.test
+++ b/test/sql/create_pg/create_property_graph.test
@@ -51,12 +51,23 @@ EDGE TABLES (
             PROPERTIES ( createDate ) LABEL Knows
     )
 
-statement ok
+query I
 -SELECT count(id)
 FROM
   GRAPH_TABLE (PG 
     MATCH p = (s1:Person)-[k:Knows]->(s2:Person WHERE s2.name='Daniel') 
     COLUMNS (s1.id));
+----
+0
+
+query I
+-SELECT count(id)
+FROM
+  GRAPH_TABLE (PG 
+    MATCH p = (s1:Person)-[k:Knows]->(s2:Person WHERE s2.name='Peter') 
+    COLUMNS (s1.id));
+----
+3
 
 # Error as property graph pg already exists
 statement error


### PR DESCRIPTION
Fix issue: https://github.com/cwida/duckpgq-extension/issues/176

Tables names are case-insensitive. Example SQL to display:
```
-- Create table with lower-case.
D CREATE TABLE test_person (name TEXT);
-- Query table with upper-case.
D SELECT * FROM Test_person;
┌─────────┐
│  name   │
│ varchar │
├─────────┤
│ 0 rows  │
└─────────┘
```

This PR uses case-intensitive map to store registered property graphs.

Test result:
```
ubuntu@hjiang-devbox-pg$ ./build/debug/duckdb
v1.1.4-dev1 c380346433
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
D CREATE TABLE Student(id BIGINT, name VARCHAR);
D CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);
D CREATE TABLE School(school_name VARCHAR, school_id BIGINT, school_kind BIGINT);
D INSERT INTO Student VALUES (0, 'Daniel'), (1, 'Tavneet'), (2, 'Gabor'), (3, 'Peter');
D INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (1,2, 14), (1,3, 15), (2,3, 16);
D -CREATE PROPERTY GRAPH pg VERTEX TABLES (    Student PROPERTIES ( id, name ) LABEL Person,    School as school_alias PROPERTIES ( school_id, school_name ) LABEL School IN School_kind (Hogeschool, University)    )EDGE TABLES (    know    SOURCE KEY ( src ) REFERENCES Student ( id )            DESTINATION KEY ( dst ) REFERENCES Student ( id )            PROPERTIES ( createDate ) LABEL Knows    );
┌─────────┐
│ Success │
│ boolean │
├─────────┤
│ 0 rows  │
└─────────┘
D -SELECT count(id)FROM  GRAPH_TABLE (PG     MATCH p = (s1:Person)-[k:Knows]->(s2:Person WHERE s2.name='Daniel')     COLUMNS (s1.id));
┌───────────┐
│ count(id) │
│   int64   │
├───────────┤
│         0 │
└───────────┘
D -SELECT count(id)FROM  GRAPH_TABLE (PG     MATCH p = (s1:Person)-[k:Knows]->(s2:Person WHERE s2.name='Tavneet')     COLUMNS (s1.id));
┌───────────┐
│ count(id) │
│   int64   │
├───────────┤
│         1 │
└───────────┘
D -SELECT count(id)FROM  GRAPH_TABLE (PG     MATCH p = (s1:Person)-[k:Knows]->(s2:Person WHERE s2.name='Gabor')     COLUMNS (s1.id));
┌───────────┐
│ count(id) │
│   int64   │
├───────────┤
│         2 │
└───────────┘
D -SELECT count(id)FROM  GRAPH_TABLE (PG     MATCH p = (s1:Person)-[k:Knows]->(s2:Person WHERE s2.name='Peter')     COLUMNS (s1.id));
┌───────────┐
│ count(id) │
│   int64   │
├───────────┤
│         3 │
└───────────┘
```