### PR TITLE
Fix segmentation fault when match was used inside subquery

### DIFF
--- a/src/core/parser/duckpgq_parser.cpp
+++ b/src/core/parser/duckpgq_parser.cpp
@@ -35,9 +35,6 @@ ParserExtensionParseResult duckpgq_parse(ParserExtensionInfo *info,
           std::move(parser.statements[0])));
 }
 
-ParserExtensionPlanResult
-duckpgq_handle_statement(SQLStatement *statement, DuckPGQState &duckpgq_state);
-
 void duckpgq_find_match_function(TableRef *table_ref,
                                  DuckPGQState &duckpgq_state) {
   // TODO(dtenwolde) add support for other style of tableRef (e.g. PivotRef)

--- a/src/core/parser/duckpgq_parser.cpp
+++ b/src/core/parser/duckpgq_parser.cpp
@@ -58,66 +58,75 @@ void duckpgq_find_match_function(TableRef *table_ref,
     duckpgq_find_match_function(join_ref->right.get(), duckpgq_state);
   } else if (auto subquery_ref = dynamic_cast<SubqueryRef *>(table_ref)) {
     // Handle SubqueryRef case
-    duckpgq_handle_statement(subquery_ref->subquery.get(), duckpgq_state);
+    auto subquery = subquery_ref->subquery.get();
+    duckpgq_find_select_statement(subquery, duckpgq_state);
   }
+}
+
+ParserExtensionPlanResult duckpgq_find_select_statement(SQLStatement *statement, DuckPGQState &duckpgq_state) {
+  const auto select_statement = dynamic_cast<SelectStatement *>(statement);
+  auto node = dynamic_cast<SelectNode *>(select_statement->node.get());
+  CTENode *cte_node = nullptr;
+
+  // Check if node is not a SelectNode
+  if (!node) {
+    // Attempt to cast to CTENode
+    cte_node = dynamic_cast<CTENode *>(select_statement->node.get());
+    if (cte_node) {
+      // Get the child node as a SelectNode if cte_node is valid
+      node = dynamic_cast<SelectNode *>(cte_node->child.get());
+    }
+  }
+
+  // Check if node is a ShowRef
+  if (node) {
+    const auto describe_node =
+        dynamic_cast<ShowRef *>(node->from_table.get());
+    if (describe_node) {
+      ParserExtensionPlanResult result;
+      result.function = DescribePropertyGraphFunction();
+      result.requires_valid_transaction = true;
+      result.return_type = StatementReturnType::QUERY_RESULT;
+      return result;
+    }
+  }
+
+  // Collect CTE keys
+  vector<string> cte_keys;
+  if (node) {
+    cte_keys = node->cte_map.map.Keys();
+  } else if (cte_node) {
+    cte_keys = cte_node->cte_map.map.Keys();
+  }
+  for (auto &key : cte_keys) {
+    auto cte = node->cte_map.map.find(key);
+    auto cte_select_statement =
+        dynamic_cast<SelectStatement *>(cte->second->query.get());
+    if (cte_select_statement == nullptr) {
+      continue; // Skip non-select statements
+    }
+    auto cte_node =
+        dynamic_cast<SelectNode *>(cte_select_statement->node.get());
+    if (cte_node) {
+      duckpgq_find_match_function(cte_node->from_table.get(), duckpgq_state);
+    }
+  }
+  if (node) {
+    duckpgq_find_match_function(node->from_table.get(), duckpgq_state);
+  } else {
+    throw Exception(ExceptionType::INTERNAL, "node is a nullptr.");
+  }
+  return {};
 }
 
 ParserExtensionPlanResult
 duckpgq_handle_statement(SQLStatement *statement, DuckPGQState &duckpgq_state) {
   if (statement->type == StatementType::SELECT_STATEMENT) {
-    const auto select_statement = dynamic_cast<SelectStatement *>(statement);
-    auto node = dynamic_cast<SelectNode *>(select_statement->node.get());
-    CTENode *cte_node = nullptr;
-
-    // Check if node is not a SelectNode
-    if (!node) {
-      // Attempt to cast to CTENode
-      cte_node = dynamic_cast<CTENode *>(select_statement->node.get());
-      if (cte_node) {
-        // Get the child node as a SelectNode if cte_node is valid
-        node = dynamic_cast<SelectNode *>(cte_node->child.get());
-      }
+    auto result = duckpgq_find_select_statement(statement, duckpgq_state);
+    if (result.function.bind == nullptr) {
+      throw Exception(ExceptionType::BINDER, "use duckpgq_bind instead");
     }
-
-    // Check if node is a ShowRef
-    if (node) {
-      const auto describe_node =
-          dynamic_cast<ShowRef *>(node->from_table.get());
-      if (describe_node) {
-        ParserExtensionPlanResult result;
-        result.function = DescribePropertyGraphFunction();
-        result.requires_valid_transaction = true;
-        result.return_type = StatementReturnType::QUERY_RESULT;
-        return result;
-      }
-    }
-
-    // Collect CTE keys
-    vector<string> cte_keys;
-    if (node) {
-      cte_keys = node->cte_map.map.Keys();
-    } else if (cte_node) {
-      cte_keys = cte_node->cte_map.map.Keys();
-    }
-    for (auto &key : cte_keys) {
-      auto cte = node->cte_map.map.find(key);
-      auto cte_select_statement =
-          dynamic_cast<SelectStatement *>(cte->second->query.get());
-      if (cte_select_statement == nullptr) {
-        continue; // Skip non-select statements
-      }
-      auto cte_node =
-          dynamic_cast<SelectNode *>(cte_select_statement->node.get());
-      if (cte_node) {
-        duckpgq_find_match_function(cte_node->from_table.get(), duckpgq_state);
-      }
-    }
-    if (node) {
-      duckpgq_find_match_function(node->from_table.get(), duckpgq_state);
-    } else {
-      throw Exception(ExceptionType::INTERNAL, "node is a nullptr.");
-    }
-    throw Exception(ExceptionType::BINDER, "use duckpgq_bind instead");
+    return result;
   }
   if (statement->type == StatementType::CREATE_STATEMENT) {
     const auto &create_statement = statement->Cast<CreateStatement>();

--- a/src/core/parser/duckpgq_parser.cpp
+++ b/src/core/parser/duckpgq_parser.cpp
@@ -40,6 +40,7 @@ duckpgq_handle_statement(SQLStatement *statement, DuckPGQState &duckpgq_state);
 
 void duckpgq_find_match_function(TableRef *table_ref,
                                  DuckPGQState &duckpgq_state) {
+  // TODO(dtenwolde) add support for other style of tableRef (e.g. PivotRef)
   if (auto table_function_ref = dynamic_cast<TableFunctionRef *>(table_ref)) {
     // Handle TableFunctionRef case
     auto function =

--- a/src/core/parser/duckpgq_parser.cpp
+++ b/src/core/parser/duckpgq_parser.cpp
@@ -15,6 +15,7 @@
 #include <duckpgq/core/functions/table/describe_property_graph.hpp>
 #include <duckpgq/core/functions/table/drop_property_graph.hpp>
 #include "duckdb/parser/query_node/cte_node.hpp"
+#include "duckdb/parser/tableref/subqueryref.hpp"
 
 namespace duckpgq {
 
@@ -33,6 +34,9 @@ ParserExtensionParseResult duckpgq_parse(ParserExtensionInfo *info,
       make_uniq_base<ParserExtensionParseData, DuckPGQParseData>(
           std::move(parser.statements[0])));
 }
+
+ParserExtensionPlanResult
+duckpgq_handle_statement(SQLStatement *statement, DuckPGQState &duckpgq_state);
 
 void duckpgq_find_match_function(TableRef *table_ref,
                                  DuckPGQState &duckpgq_state) {
@@ -54,6 +58,9 @@ void duckpgq_find_match_function(TableRef *table_ref,
     // Handle JoinRef case
     duckpgq_find_match_function(join_ref->left.get(), duckpgq_state);
     duckpgq_find_match_function(join_ref->right.get(), duckpgq_state);
+  } else if (auto subquery_ref = dynamic_cast<SubqueryRef *>(table_ref)) {
+    // Handle SubqueryRef case
+    duckpgq_handle_statement(subquery_ref->subquery.get(), duckpgq_state);
   }
 }
 

--- a/src/include/duckpgq/core/parser/duckpgq_parser.hpp
+++ b/src/include/duckpgq/core/parser/duckpgq_parser.hpp
@@ -26,6 +26,9 @@ ParserExtensionPlanResult duckpgq_plan(ParserExtensionInfo *info,
                                        ClientContext &,
                                        unique_ptr<ParserExtensionParseData>);
 
+ParserExtensionPlanResult duckpgq_find_select_statement(
+  SQLStatement *statement, DuckPGQState &duckpgq_state);
+
 ParserExtensionPlanResult
 duckpgq_handle_statement(SQLStatement *statement, DuckPGQState &duckpgq_state);
 

--- a/src/include/duckpgq/core/parser/duckpgq_parser.hpp
+++ b/src/include/duckpgq/core/parser/duckpgq_parser.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include "duckpgq/common.hpp"
 
+#include <duckpgq_state.hpp>
+
 namespace duckpgq {
 
 namespace core {
@@ -25,7 +27,10 @@ ParserExtensionPlanResult duckpgq_plan(ParserExtensionInfo *info,
                                        unique_ptr<ParserExtensionParseData>);
 
 ParserExtensionPlanResult
-duckpgq_handle_statement(unique_ptr<SQLStatement> &statement);
+duckpgq_handle_statement(SQLStatement *statement, DuckPGQState &duckpgq_state);
+
+void duckpgq_find_match_function(TableRef *table_ref,
+                                 DuckPGQState &duckpgq_state);
 
 struct DuckPGQParserExtension : ParserExtension {
   DuckPGQParserExtension() : ParserExtension() {

--- a/test/sql/nested_subquery.test
+++ b/test/sql/nested_subquery.test
@@ -1,0 +1,32 @@
+
+
+require duckpgq
+
+statement ok
+CREATE TABLE Student(id BIGINT, name VARCHAR);INSERT INTO Student VALUES (0, 'Daniel'), (1, 'Tavneet'), (2, 'Gabor'), (3, 'Peter'), (4, 'David');
+
+statement ok
+CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (3,0, 13), (1,2, 14), (1,3, 15), (2,3, 16), (4,3, 17);
+
+statement ok
+CREATE TABLE School(name VARCHAR, Id BIGINT, Kind VARCHAR);INSERT INTO School VALUES ('VU', 0, 'University'), ('UVA', 1, 'University');
+
+statement ok
+CREATE TABLE StudyAt(personId BIGINT, schoolId BIGINT);INSERT INTO StudyAt VALUES (0, 0), (1, 0), (2, 1), (3, 1), (4, 1);
+
+statement ok
+-CREATE PROPERTY GRAPH pg
+VERTEX TABLES (
+    Student PROPERTIES ( id, name ) LABEL Person,
+    School LABEL SCHOOL
+    )
+EDGE TABLES (
+    know    SOURCE KEY ( src ) REFERENCES Student ( id )
+            DESTINATION KEY ( dst ) REFERENCES Student ( id ),
+    studyAt SOURCE KEY ( personId ) REFERENCES Student ( id )
+            DESTINATION KEY ( SchoolId ) REFERENCES School ( id )
+    );
+
+
+statement ok
+-select * from (select id, id_1 from graph_table ( pg match (p:person)-[k:know]->(p2:person) columns (p.id, p2.id)));

--- a/test/sql/nested_subquery.test
+++ b/test/sql/nested_subquery.test
@@ -83,3 +83,14 @@ FROM (
     GROUP BY id
 );
 
+statement ok
+-WITH Friendships AS (
+    SELECT person_id, friend_id
+    FROM (
+        SELECT person_id, friend_id
+        FROM GRAPH_TABLE (
+            pg MATCH (p:Person)-[k:know]->(p2:Person) COLUMNS (p.id as person_id, p2.id as friend_id)
+        )
+    ) AS Subquery
+)
+SELECT * FROM Friendships;

--- a/test/sql/nested_subquery.test
+++ b/test/sql/nested_subquery.test
@@ -30,3 +30,56 @@ EDGE TABLES (
 
 statement ok
 -select * from (select id, id_1 from graph_table ( pg match (p:person)-[k:know]->(p2:person) columns (p.id, p2.id)));
+
+statement ok
+-SELECT id, friend_id
+FROM (
+    SELECT id, friend_id
+    FROM GRAPH_TABLE (
+        pg MATCH (p:Person)-[k:know]->(p2:Person) COLUMNS (p.id as id, p2.id as friend_id)
+    ) graph
+);
+
+statement ok
+-SELECT id, friend_id
+FROM (
+    SELECT id, friend_id
+    FROM GRAPH_TABLE (
+        pg MATCH (p:Person)-[k:know]->(p2:Person) COLUMNS (p.id as id, p2.id as friend_id)
+    ) graph
+    WHERE id > 1
+);
+
+statement ok
+-SELECT Student.name, friend_id
+FROM Student
+JOIN (
+    SELECT student_id, friend_id
+    FROM GRAPH_TABLE (
+        pg MATCH (p:Person)-[k:know]->(p2:Person) COLUMNS (p.id as student_id, p2.id as friend_id)
+    ) graph
+) AS subquery
+ON Student.id = subquery.student_id;
+
+statement ok
+-SELECT id, nested_friend_id
+FROM (
+    SELECT id, friend_id AS nested_friend_id
+    FROM (
+        SELECT id, friend_id
+        FROM GRAPH_TABLE (
+            pg MATCH (p:Person)-[k:know]->(p2:Person) COLUMNS (p.id as id, p2.id as friend_id)
+        )
+    )
+);
+
+statement ok
+-SELECT id, friend_count
+FROM (
+    SELECT id, COUNT(friend_id) AS friend_count
+    FROM GRAPH_TABLE (
+        pg MATCH (p:Person)-[k:know]->(p2:Person) COLUMNS (p.id as id, p2.id as friend_id)
+    )
+    GROUP BY id
+);
+


### PR DESCRIPTION
Fixes #199 

We now also check if the `from_table` contains a `SubqueryRef`, which is then traversed to detect a potential `MATCH` statement. Before, the match wasn't found, resulting in the incorrect code path being taken. 

I've also moved the logic for `select_statements` to a separate function since the select statement and the subquery share these. 

Need to add a few more test cases before I will merge this. 

