### PR TITLE
changed link to new doc in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DuckPGQ
-A DuckDB extension for graph workloads that supports the SQL/PGQ standard. For more information, please see the [documentation page](https://duckpgq.notion.site/duckpgq/b8ac652667964f958bfada1c3e53f1bb?v=3b47a8d44bdf4e0c8b503bf23f1b76f2).
+A DuckDB extension for graph workloads that supports the SQL/PGQ standard. For more information, please see the [documentation page](https://duckpgq.org/).
 
 [![Discord](https://discordapp.com/api/guilds/1225369321077866496/widget.png?style=banner3)](https://discord.gg/8X95XHhQB7)
 ## WIP Disclaimer


### PR DESCRIPTION
there is a link to old doc in readme
<img width="325" alt="2025-02-19_22h30_34" src="https://github.com/user-attachments/assets/fc8859e5-8661-4449-9736-ec596734aaad" />
