### PR TITLE
Allow property graph creation across different schemas

### DIFF
--- a/src/core/functions/table/create_property_graph.cpp
+++ b/src/core/functions/table/create_property_graph.cpp
@@ -8,6 +8,8 @@
 #include "duckdb/main/connection_manager.hpp"
 #include <duckpgq/core/parser/duckpgq_parser.hpp>
 #include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
+#include "duckdb/catalog/catalog.hpp"
+
 
 namespace duckpgq {
 namespace core {
@@ -214,8 +216,9 @@ unique_ptr<FunctionData> CreatePropertyGraphFunction::CreatePropertyGraphBind(
   case_insensitive_set_t v_table_names;
   for (auto &vertex_table : info->vertex_tables) {
     try {
-      auto &catalog = Catalog::GetCatalog(context, vertex_table->catalog_name);
-      auto table = GetTableCatalogEntry(context, vertex_table);
+      auto &table = Catalog::GetEntry<TableCatalogEntry>(context, vertex_table->catalog_name, vertex_table->schema_name, vertex_table->table_name);
+      // auto catalog_entry = schema.GetEntry(schema.catalog.GetCatalogTransaction(context), CatalogType::TABLE_ENTRY, vertex_table->table_name);
+      // auto &table = catalog_entry->Cast<TableCatalogEntry>();
       CheckPropertyGraphTableColumns(vertex_table, table);
       CheckPropertyGraphTableLabels(vertex_table, table);
     } catch (CatalogException &e) {

--- a/src/core/functions/table/create_property_graph.cpp
+++ b/src/core/functions/table/create_property_graph.cpp
@@ -214,6 +214,7 @@ unique_ptr<FunctionData> CreatePropertyGraphFunction::CreatePropertyGraphBind(
   case_insensitive_set_t v_table_names;
   for (auto &vertex_table : info->vertex_tables) {
     try {
+      auto &catalog = Catalog::GetCatalog(context, vertex_table->catalog_name);
       auto table = GetTableCatalogEntry(context, vertex_table);
       CheckPropertyGraphTableColumns(vertex_table, table);
       CheckPropertyGraphTableLabels(vertex_table, table);

--- a/src/duckpgq_state.cpp
+++ b/src/duckpgq_state.cpp
@@ -18,7 +18,12 @@ DuckPGQState::DuckPGQState(shared_ptr<ClientContext> context) {
                                "discriminator varchar, "
                                "sub_labels varchar[], "
                                "catalog varchar, "
-                               "schema varchar)",
+                               "schema varchar,"
+                               "source_catalog varchar, "
+                               "source_schema varchar, "
+                               "destination_catalog varchar, "
+                               "destination_schema varchar"
+                               ")",
                                false);
   if (query->HasError()) {
     throw TransactionException(query->GetError());
@@ -62,7 +67,7 @@ void DuckPGQState::ProcessPropertyGraphs(
     table->table_name = chunk->GetValue(1, i).GetValue<string>();
     table->main_label = chunk->GetValue(2, i).GetValue<string>();
     table->is_vertex_table = chunk->GetValue(3, i).GetValue<bool>();
-    table->all_columns = true; // TODO: Be stricter on properties
+    table->all_columns = true; // todo(dtenwolde) Be stricter on properties
 
     // Handle discriminator and sub-labels
     const auto &discriminator = chunk->GetValue(10, i).GetValue<string>();
@@ -75,12 +80,23 @@ void DuckPGQState::ProcessPropertyGraphs(
     }
 
     // Extract catalog and schema names
-    if (chunk->ColumnCount() == 14) {
+    if (chunk->ColumnCount() > 12) {
       table->catalog_name = chunk->GetValue(12, i).GetValue<string>();
       table->schema_name = chunk->GetValue(13, i).GetValue<string>();
     } else {
       table->catalog_name = "";
       table->schema_name = DEFAULT_SCHEMA;
+    }
+    if (chunk->ColumnCount() > 14) {
+      table->source_catalog = chunk->GetValue(14, i).GetValue<string>();
+      table->source_schema = chunk->GetValue(15, i).GetValue<string>();
+      table->destination_catalog = chunk->GetValue(16, i).GetValue<string>();
+      table->destination_schema = chunk->GetValue(17, i).GetValue<string>();
+    } else {
+      table->source_catalog = "";
+      table->schema_name = DEFAULT_SCHEMA;
+      table->destination_catalog = "";
+      table->destination_schema = DEFAULT_SCHEMA;
     }
 
     // Additional edge-specific handling
@@ -136,10 +152,10 @@ void DuckPGQState::RegisterPropertyGraph(
   if (is_vertex) {
     pg_info.vertex_tables.push_back(table);
   } else {
-    table->source_pg_table = pg_info.GetTableByName(table->source_reference);
+    table->source_pg_table = pg_info.GetTableByName(table->source_catalog, table->source_schema, table->source_reference);
     D_ASSERT(table->source_pg_table);
     table->destination_pg_table =
-        pg_info.GetTableByName(table->destination_reference);
+        pg_info.GetTableByName(table->destination_catalog, table->destination_schema, table->destination_reference);
     D_ASSERT(table->destination_pg_table);
     pg_info.edge_tables.push_back(table);
   }

--- a/src/include/duckpgq/core/functions/table/create_property_graph.hpp
+++ b/src/include/duckpgq/core/functions/table/create_property_graph.hpp
@@ -56,10 +56,8 @@ public:
   ValidateVertexTableRegistration(const string &reference,
                                   const case_insensitive_set_t &v_table_names);
 
-  static void ValidatePrimaryKeyInTable(Catalog &catalog,
-                                        ClientContext &context,
-                                        const string &schema,
-                                        const string &reference,
+  static void ValidatePrimaryKeyInTable(ClientContext &context,
+                                        shared_ptr<PropertyGraphTable> &pg_table,
                                         const vector<string> &pk_columns);
 
   static void
@@ -71,7 +69,7 @@ public:
   static void
   ValidateForeignKeyColumns(shared_ptr<PropertyGraphTable> &edge_table,
                             const vector<string> &fk_columns,
-                            TableCatalogEntry &table);
+                            optional_ptr<TableCatalogEntry> &table);
 
   static unique_ptr<GlobalTableFunctionState>
   CreatePropertyGraphInit(ClientContext &context,

--- a/src/include/duckpgq/core/functions/table/create_property_graph.hpp
+++ b/src/include/duckpgq/core/functions/table/create_property_graph.hpp
@@ -53,7 +53,7 @@ public:
                           vector<string> &names);
 
   static void
-  ValidateVertexTableRegistration(const string &reference,
+  ValidateVertexTableRegistration(shared_ptr<PropertyGraphTable> &pg_table,
                                   const case_insensitive_set_t &v_table_names);
 
   static void ValidatePrimaryKeyInTable(ClientContext &context,

--- a/src/include/duckpgq/core/functions/table/create_property_graph.hpp
+++ b/src/include/duckpgq/core/functions/table/create_property_graph.hpp
@@ -44,7 +44,8 @@ public:
   CheckPropertyGraphTableColumns(const shared_ptr<PropertyGraphTable> &pg_table,
                                  TableCatalogEntry &table);
 
-  static reference<TableCatalogEntry> GetTableCatalogEntry(ClientContext &context, shared_ptr<PropertyGraphTable> &pg_table);
+  static reference<TableCatalogEntry> GetTableCatalogEntry(ClientContext &context,
+    shared_ptr<PropertyGraphTable> &pg_table);
 
   static unique_ptr<FunctionData>
   CreatePropertyGraphBind(ClientContext &context, TableFunctionBindInput &input,

--- a/src/include/duckpgq/core/functions/table/create_property_graph.hpp
+++ b/src/include/duckpgq/core/functions/table/create_property_graph.hpp
@@ -38,11 +38,11 @@ public:
 
   static void
   CheckPropertyGraphTableLabels(const shared_ptr<PropertyGraphTable> &pg_table,
-                                TableCatalogEntry &table);
+                                optional_ptr<TableCatalogEntry> &table);
 
   static void
   CheckPropertyGraphTableColumns(const shared_ptr<PropertyGraphTable> &pg_table,
-                                 TableCatalogEntry &table);
+                                 optional_ptr<TableCatalogEntry> &table);
 
   static reference<TableCatalogEntry> GetTableCatalogEntry(ClientContext &context,
     shared_ptr<PropertyGraphTable> &pg_table);

--- a/test/sql/211_using_other_schemas.test
+++ b/test/sql/211_using_other_schemas.test
@@ -278,3 +278,42 @@ statement ok
 -create property graph g
 vertex tables (v,w)
 edge tables (e2 source v destination w);
+
+statement ok
+create schema myschema; set search_path = myschema;
+
+statement ok
+CREATE TABLE Person (id bigint); CREATE TABLE Person_knows_person (person1id bigint, person2id bigint);
+
+statement ok
+-CREATE OR REPLACE PROPERTY GRAPH snb
+    VERTEX TABLES (
+      Person
+    )
+    EDGE TABLES (
+      Person_knows_person SOURCE KEY (Person1Id) REFERENCES Person (id)
+                          DESTINATION KEY (Person2Id) REFERENCES Person (id)
+      LABEL knows
+    );
+
+statement ok
+-CREATE OR REPLACE PROPERTY GRAPH snb
+  VERTEX TABLES (
+    myschema.Person
+  )
+  EDGE TABLES (
+    myschema.Person_knows_person SOURCE KEY (Person1Id) REFERENCES myschema.Person (id)
+                        DESTINATION KEY (Person2Id) REFERENCES myschema.Person (id)
+    LABEL knows
+  );
+
+statement ok
+-CREATE OR REPLACE PROPERTY GRAPH snb
+  VERTEX TABLES (
+    memory.myschema.Person
+  )
+  EDGE TABLES (
+    memory.myschema.Person_knows_person SOURCE KEY (Person1Id) REFERENCES memory.myschema.Person (id)
+                        DESTINATION KEY (Person2Id) REFERENCES memory.myschema.Person (id)
+    LABEL knows
+  );

--- a/test/sql/211_using_other_schemas.test
+++ b/test/sql/211_using_other_schemas.test
@@ -297,6 +297,8 @@ statement ok
     );
 
 
+
+
 statement ok
 -FROM GRAPH_TABLE (snb MATCH (a:Person)-[k:knows]->(b:Person));
 

--- a/test/sql/211_using_other_schemas.test
+++ b/test/sql/211_using_other_schemas.test
@@ -25,25 +25,25 @@ statement ok
       LABEL knows
     );
 
-#
-# statement ok
-# -CREATE PROPERTY GRAPH snb
-#   VERTEX TABLES (
-#     myschema.Person
-#   )
-#   EDGE TABLES (
-#     myschema.Person_knows_person SOURCE KEY (Person1Id) REFERENCES myschema.Person (id)
-#                         DESTINATION KEY (Person2Id) REFERENCES myschema.Person (id)
-#     LABEL knows
-#   );
-#
-# statement ok
-# -CREATE PROPERTY GRAPH snb
-#   VERTEX TABLES (
-#     memory.myschema.Person
-#   )
-#   EDGE TABLES (
-#     memory.myschema.Person_knows_person SOURCE KEY (Person1Id) REFERENCES memory.myschema.Person (id)
-#                         DESTINATION KEY (Person2Id) REFERENCES memory.myschema.Person (id)
-#     LABEL knows
-#   );
+
+statement ok
+-CREATE OR REPLACE PROPERTY GRAPH snb
+  VERTEX TABLES (
+    myschema.Person
+  )
+  EDGE TABLES (
+    myschema.Person_knows_person SOURCE KEY (Person1Id) REFERENCES myschema.Person (id)
+                        DESTINATION KEY (Person2Id) REFERENCES myschema.Person (id)
+    LABEL knows
+  );
+
+statement ok
+-CREATE OR REPLACE PROPERTY GRAPH snb
+  VERTEX TABLES (
+    memory.myschema.Person
+  )
+  EDGE TABLES (
+    memory.myschema.Person_knows_person SOURCE KEY (Person1Id) REFERENCES memory.myschema.Person (id)
+                        DESTINATION KEY (Person2Id) REFERENCES memory.myschema.Person (id)
+    LABEL knows
+  );

--- a/test/sql/211_using_other_schemas.test
+++ b/test/sql/211_using_other_schemas.test
@@ -1,49 +1,225 @@
-
-
 require duckpgq
 
 statement ok
-create schema myschema;
+CREATE SCHEMA test_schema;
 
 statement ok
-set search_path = myschema;
+SET search_path = test_schema;
 
 statement ok
-CREATE TABLE Person(id BIGINT);
+CREATE TABLE Person(id BIGINT PRIMARY KEY, name TEXT);
 
 statement ok
-CREATE TABLE Person_knows_person(Person1Id BIGINT, Person2Id BIGINT);
+CREATE TABLE Company(id BIGINT PRIMARY KEY, name TEXT);
 
 statement ok
--CREATE PROPERTY GRAPH snb
+CREATE TABLE WorksAt(person_id BIGINT, company_id BIGINT);
+
+statement ok
+-CREATE PROPERTY GRAPH work_graph
+    VERTEX TABLES (
+      Person,
+      Company
+    )
+    EDGE TABLES (
+      WorksAt SOURCE KEY (person_id) REFERENCES Person (id)
+              DESTINATION KEY (company_id) REFERENCES Company (id)
+              LABEL works_at
+    );
+
+statement ok
+-CREATE PROPERTY GRAPH enriched_graph
+    VERTEX TABLES (
+      Person PROPERTIES (id, name),
+      Company PROPERTIES (id, name)
+    )
+    EDGE TABLES (
+      WorksAt SOURCE KEY (person_id) REFERENCES Person (id)
+              DESTINATION KEY (company_id) REFERENCES Company (id)
+              PROPERTIES (person_id, company_id)
+              LABEL works_at
+    );
+
+statement ok
+CREATE TABLE Friendship(person1_id BIGINT, person2_id BIGINT, since DATE);
+
+statement ok
+-CREATE PROPERTY GRAPH social_graph
     VERTEX TABLES (
       Person
     )
     EDGE TABLES (
-      Person_knows_person SOURCE KEY (Person1Id) REFERENCES Person (id)
-                          DESTINATION KEY (Person2Id) REFERENCES Person (id)
-      LABEL knows
+      Friendship SOURCE KEY (person1_id) REFERENCES Person (id)
+                 DESTINATION KEY (person2_id) REFERENCES Person (id)
+                 PROPERTIES (since)
+                 LABEL friends_with
     );
 
+statement ok
+-CREATE OR REPLACE PROPERTY GRAPH external_graph
+    VERTEX TABLES (
+      test_schema.Person,
+      test_schema.Company
+    )
+    EDGE TABLES (
+      test_schema.WorksAt SOURCE KEY (person_id) REFERENCES test_schema.Person (id)
+                          DESTINATION KEY (company_id) REFERENCES test_schema.Company (id)
+                          LABEL works_at
+    );
 
 statement ok
--CREATE OR REPLACE PROPERTY GRAPH snb
-  VERTEX TABLES (
-    myschema.Person
-  )
-  EDGE TABLES (
-    myschema.Person_knows_person SOURCE KEY (Person1Id) REFERENCES myschema.Person (id)
-                        DESTINATION KEY (Person2Id) REFERENCES myschema.Person (id)
-    LABEL knows
-  );
+-CREATE OR REPLACE PROPERTY GRAPH memory_graph
+    VERTEX TABLES (
+      memory.test_schema.Person,
+      memory.test_schema.Company
+    )
+    EDGE TABLES (
+      memory.test_schema.WorksAt SOURCE KEY (person_id) REFERENCES memory.test_schema.Person (id)
+                                 DESTINATION KEY (company_id) REFERENCES memory.test_schema.Company (id)
+                                 LABEL works_at
+    );
+
+statement error
+-CREATE PROPERTY GRAPH invalid_graph
+    VERTEX TABLES (
+      nonexistent_schema.Person
+    )
+    EDGE TABLES (
+      nonexistent_schema.WorksAt SOURCE KEY (person_id) REFERENCES nonexistent_schema.Person (id)
+                                 DESTINATION KEY (company_id) REFERENCES nonexistent_schema.Company (id)
+                                 LABEL works_at
+    );
+----
+Invalid Error: Table 'nonexistent_schema.Company' not found in the property graph invalid_graph.
 
 statement ok
--CREATE OR REPLACE PROPERTY GRAPH snb
-  VERTEX TABLES (
-    memory.myschema.Person
-  )
-  EDGE TABLES (
-    memory.myschema.Person_knows_person SOURCE KEY (Person1Id) REFERENCES memory.myschema.Person (id)
-                        DESTINATION KEY (Person2Id) REFERENCES memory.myschema.Person (id)
-    LABEL knows
-  );
+CREATE SCHEMA schema1;
+
+statement ok
+CREATE SCHEMA schema2;
+
+statement ok
+CREATE SCHEMA memory_schema;
+
+statement ok
+SET search_path = schema1;
+
+statement ok
+CREATE TABLE schema1.Person(id BIGINT PRIMARY KEY, name TEXT); INSERT INTO schema1.Person VALUES (1, 'Alice');
+
+statement ok
+CREATE TABLE schema2.Company(id BIGINT PRIMARY KEY, name TEXT); INSERT INTO schema2.Company VALUES (2, 'Bob B.V.');
+
+statement ok
+CREATE TABLE schema2.WorksAt(person_id BIGINT, company_id BIGINT);
+
+statement ok
+CREATE TABLE Friendship(person1_id BIGINT, person2_id BIGINT, since DATE);
+
+statement ok
+-CREATE PROPERTY GRAPH cross_schema_graph
+    VERTEX TABLES (
+      schema1.Person,
+      schema2.Company
+    )
+    EDGE TABLES (
+      schema2.WorksAt SOURCE KEY (person_id) REFERENCES schema1.Person (id)
+                      DESTINATION KEY (company_id) REFERENCES schema2.Company (id)
+                      LABEL works_at
+    );
+
+statement ok
+-CREATE PROPERTY GRAPH memory_inclusive_graph
+    VERTEX TABLES (
+      schema1.Person
+    )
+    EDGE TABLES (
+      Friendship SOURCE KEY (person1_id) REFERENCES schema1.Person (id)
+                               DESTINATION KEY (person2_id) REFERENCES schema1.Person (id)
+                               PROPERTIES (since)
+                               LABEL friends_with
+    );
+
+statement ok
+-CREATE PROPERTY GRAPH fully_qualified_graph
+    VERTEX TABLES (
+      schema1.Person,
+      schema2.Company
+    )
+    EDGE TABLES (
+      schema2.WorksAt SOURCE KEY (person_id) REFERENCES schema1.Person (id)
+                      DESTINATION KEY (company_id) REFERENCES schema2.Company (id)
+                      LABEL works_at,
+      Friendship SOURCE KEY (person1_id) REFERENCES schema1.Person (id)
+                               DESTINATION KEY (person2_id) REFERENCES schema1.Person (id)
+                               LABEL friends_with
+    );
+
+statement ok
+SET search_path = schema2;
+
+statement error
+-CREATE PROPERTY GRAPH search_path_graph
+    VERTEX TABLES (
+      Person, -- Should resolve to schema1.Person
+      Company
+    )
+    EDGE TABLES (
+      WorksAt SOURCE KEY (person_id) REFERENCES Person (id)
+              DESTINATION KEY (company_id) REFERENCES Company (id)
+              LABEL works_at
+    );
+----
+Invalid Error: Table with name Person does not exist
+
+statement ok
+-CREATE PROPERTY GRAPH search_path_graph
+    VERTEX TABLES (
+      schema1.Person, -- Should resolve to schema1.Person
+      Company
+    )
+    EDGE TABLES (
+      WorksAt SOURCE KEY (person_id) REFERENCES schema1.Person (id)
+              DESTINATION KEY (company_id) REFERENCES Company (id)
+              LABEL works_at
+    );
+
+statement error
+CREATE PROPERTY GRAPH invalid_schema_graph
+    VERTEX TABLES (
+      nonexistent_schema.Person
+    )
+    EDGE TABLES (
+      nonexistent_schema.WorksAt SOURCE KEY (person_id) REFERENCES nonexistent_schema.Person (id)
+                                 DESTINATION KEY (company_id) REFERENCES nonexistent_schema.Company (id)
+                                 LABEL works_at
+    );
+----
+Invalid Error: Table 'nonexistent_schema.Company' not found in the property graph invalid_schema_graph.
+
+statement error
+-CREATE PROPERTY GRAPH conflicting_schemas
+    VERTEX TABLES (
+      schema1.Person,
+      schema2.Person  -- Duplicate table name in different schema
+    )
+    EDGE TABLES (
+      schema2.WorksAt SOURCE KEY (person_id) REFERENCES schema1.Person (id)
+                      DESTINATION KEY (company_id) REFERENCES schema2.Company (id)
+                      LABEL works_at
+    );
+----
+Constraint Error: Label person is not unique, make sure all labels are unique
+
+statement error
+CREATE PROPERTY GRAPH wrong_schema_reference
+    VERTEX TABLES (
+      schema1.Person
+    )
+    EDGE TABLES (
+      schema2.WorksAt SOURCE KEY (person_id) REFERENCES schema1.Person (id)
+                      DESTINATION KEY (company_id) REFERENCES schema1.Company (id) -- Incorrect reference
+                      LABEL works_at
+    );
+----
+Invalid Error: Table 'schema1.Company' not found in the property graph wrong_schema_reference.

--- a/test/sql/211_using_other_schemas.test
+++ b/test/sql/211_using_other_schemas.test
@@ -223,3 +223,58 @@ CREATE PROPERTY GRAPH wrong_schema_reference
     );
 ----
 Invalid Error: Table 'schema1.Company' not found in the property graph wrong_schema_reference.
+
+
+
+statement ok
+create table schema2.v (
+    id BIGINT primary key,
+    name varchar
+);
+
+statement ok
+INSERT INTO schema2.v VALUES (1, 'a');
+
+statement error
+create table schema1.e (
+    id bigint primary key,
+    src BIGINT REFERENCES v(id),
+    dst BIGINT REFERENCES v(id)
+);
+----
+Binder Error: Creating foreign keys across different schemas or catalogs is not supported
+
+statement ok
+create table schema2.e (
+    id bigint primary key,
+    src BIGINT REFERENCES schema2.v(id),
+    dst BIGINT REFERENCES schema2.v(id)
+);
+
+statement error
+-create property graph g
+vertex tables (schema2.v)
+edge tables (schema2.e source schema2.v destination schema2.v);
+----
+Invalid Error: Multiple primary key - foreign key relationships detected between e and v. Please explicitly define the primary key and foreign key columns using `SOURCE KEY <primary key> REFERENCES v <foreign key>`
+
+statement ok
+create table schema2.w (
+    id BIGINT primary key,
+    name varchar
+);
+
+statement ok
+INSERT INTO schema2.w VALUES (2, 'b');
+
+statement ok
+create table schema2.e2 (
+    id bigint primary key,
+    src BIGINT REFERENCES schema2.v(id),
+    dst BIGINT REFERENCES schema2.w(id)
+);
+
+statement ok
+-create property graph g
+vertex tables (v,w)
+edge tables (e2 source v destination w);

--- a/test/sql/211_using_other_schemas.test
+++ b/test/sql/211_using_other_schemas.test
@@ -297,6 +297,9 @@ statement ok
     );
 
 statement ok
+-FROM GRAPH_TABLE (snb MATCH (a:Person)-[k:knows]->(b:Person));
+
+statement ok
 -CREATE OR REPLACE PROPERTY GRAPH snb
   VERTEX TABLES (
     myschema.Person
@@ -308,6 +311,9 @@ statement ok
   );
 
 statement ok
+-FROM GRAPH_TABLE (snb MATCH (a:Person)-[k:knows]->(b:Person));
+
+statement ok
 -CREATE OR REPLACE PROPERTY GRAPH snb
   VERTEX TABLES (
     memory.myschema.Person
@@ -317,3 +323,6 @@ statement ok
                         DESTINATION KEY (Person2Id) REFERENCES memory.myschema.Person (id)
     LABEL knows
   );
+
+statement ok
+-FROM GRAPH_TABLE (snb MATCH (a:Person)-[k:knows]->(b:Person));

--- a/test/sql/211_using_other_schemas.test
+++ b/test/sql/211_using_other_schemas.test
@@ -296,6 +296,7 @@ statement ok
       LABEL knows
     );
 
+
 statement ok
 -FROM GRAPH_TABLE (snb MATCH (a:Person)-[k:knows]->(b:Person));
 

--- a/test/sql/create_pg/attach_pg.test
+++ b/test/sql/create_pg/attach_pg.test
@@ -27,7 +27,7 @@ Invalid Error: Catalog 'nonexistingcatalog' does not exist!
 statement error
 -create or replace property graph stations vertex tables (bluesky.tabledoesnotexist)
 ----
-Invalid Error: Table bluesky.tabledoesnotexist not found
+Invalid Error: Table tabledoesnotexist not found
 
 statement ok con1
 -CREATE OR REPLACE PROPERTY GRAPH bluesky

--- a/test/sql/create_pg/attach_pg.test
+++ b/test/sql/create_pg/attach_pg.test
@@ -15,12 +15,12 @@ select count(*) from bluesky.follows;
 statement error
 -create or replace property graph stations vertex tables (stations.stations)
 ----
-Invalid Error: Catalog 'stations' does not exist!
+Invalid Error: Table stations not found
 
 statement error
--create or replace property graph stations vertex tables (bluesky.account)
-    edge tables (nonexistingcatalog.follows source key (source) references bluesky.account (did)
-        destination key (destination) references bluesky.account (did))
+-create or replace property graph stations vertex tables (nonexistingschema.account)
+    edge tables (nonexistingschema.follows source key (source) references nonexistingschema.account (did)
+        destination key (destination) references nonexistingschema.account (did))
 ----
 Invalid Error: Catalog 'nonexistingcatalog' does not exist!
 

--- a/test/sql/create_pg/attach_pg.test
+++ b/test/sql/create_pg/attach_pg.test
@@ -15,19 +15,19 @@ select count(*) from bluesky.follows;
 statement error
 -create or replace property graph stations vertex tables (stations.stations)
 ----
-Invalid Error: Table stations not found
+Invalid Error: Table with name stations does not exist
 
 statement error
 -create or replace property graph stations vertex tables (nonexistingschema.account)
     edge tables (nonexistingschema.follows source key (source) references nonexistingschema.account (did)
         destination key (destination) references nonexistingschema.account (did))
 ----
-Invalid Error: Catalog 'nonexistingcatalog' does not exist!
+Invalid Error: Table with name account does not exist
 
 statement error
 -create or replace property graph stations vertex tables (bluesky.tabledoesnotexist)
 ----
-Invalid Error: Table tabledoesnotexist not found
+Invalid Error: Table with name tabledoesnotexist does not exist
 
 statement ok con1
 -CREATE OR REPLACE PROPERTY GRAPH bluesky

--- a/test/sql/create_pg/attach_pg.test
+++ b/test/sql/create_pg/attach_pg.test
@@ -25,6 +25,20 @@ statement error
 Invalid Error: Table with name account does not exist
 
 statement error
+-create or replace property graph stations vertex tables (bluesky.account)
+    edge tables (nonexistingschema.follows source key (source) references bluesky.account (did)
+        destination key (destination) references bluesky.account (did))
+----
+Invalid Error: Table with name follows does not exist
+
+statement error
+-create or replace property graph stations vertex tables (bluesky.account)
+    edge tables (bluesky.follows source key (source) references nonexistingschema.account (did)
+        destination key (destination) references nonexistingschema.account (did))
+----
+Invalid Error: Table 'nonexistingschema.account' not found in the property graph stations.
+
+statement error
 -create or replace property graph stations vertex tables (bluesky.tabledoesnotexist)
 ----
 Invalid Error: Table with name tabledoesnotexist does not exist

--- a/test/sql/create_pg/create_property_graph.test
+++ b/test/sql/create_pg/create_property_graph.test
@@ -11,8 +11,7 @@ statement error
 -CREATE PROPERTY GRAPH pg4
 VERTEX TABLES (tabledoesnotexist);
 ----
-Invalid Error: Table main.tabledoesnotexist not found
-
+Invalid Error: Table with name tabledoesnotexist does not exist
 
 statement ok
 CREATE TABLE Student(id BIGINT, name VARCHAR);
@@ -24,7 +23,7 @@ EDGE TABLES (edgetabledoesnotexist SOURCE KEY (id) REFERENCES Student (id)
                                     DESTINATION KEY (id) REFERENCES Student (id)
             );
 ----
-Invalid Error: Table main.edgetabledoesnotexist not found
+Invalid Error: Table with name edgetabledoesnotexist does not exist
 
 statement ok
 CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);

--- a/test/sql/create_pg/describe_pg.test
+++ b/test/sql/create_pg/describe_pg.test
@@ -21,8 +21,8 @@ EDGE TABLES (
 query IIIIIIIIIIIIII
 -DESCRIBE PROPERTY GRAPH snb;
 ----
-snb	Person	person	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
-snb	Person_knows_person	knows	false	Person	[id]	[Person1Id]	Person	[id]	[Person2Id]	NULL	NULL	NULL	main
+snb	Person	person	1	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	(empty)
+snb	Person_knows_person	knows	0	Person	[id]	[Person1Id]	Person	[id]	[Person2Id]	NULL	NULL	NULL	(empty)
 
 statement ok
 -CREATE OR REPLACE PROPERTY GRAPH snb
@@ -70,24 +70,25 @@ EDGE TABLES (
 query IIIIIIIIIIIIII
 -DESCRIBE PROPERTY GRAPH snb;
 ----
-snb	Message	message	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
-snb	City	city	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
-snb	Country	country	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
-snb	TagClass	tagclass	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
-snb	Tag	tag	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
-snb	Place	place	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
-snb	Organisation	organisation	true	NULL	NULL	NULL	NULL	NULL	NULL	typemask	[company, university]	NULL	main
-snb	Forum	forum	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
-snb	Person	person	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	main
-snb	Message_replyOf_Message	replyof	false	Message	[id]	[messageId]	Message	[id]	[ParentMessageId]	NULL	NULL	NULL	main
-snb	Message_hasAuthor_Person	hasauthor	false	Message	[id]	[messageId]	Person	[id]	[PersonId]	NULL	NULL	NULL	main
-snb	Message_hasTag_Tag	message_hastag	false	Message	[id]	[id]	Tag	[id]	[TagId]	NULL	NULL	NULL	main
-snb	Person_likes_Message	likes_message	false	Person	[id]	[PersonId]	Message	[id]	[id]	NULL	NULL	NULL	main
-snb	person_workAt_Organisation	workat_organisation	false	Person	[id]	[PersonId]	Organisation	[id]	[OrganisationId]	NULL	NULL	NULL	main
-snb	Person_hasInterest_Tag	hasinterest	false	Person	[id]	[PersonId]	Tag	[id]	[TagId]	NULL	NULL	NULL	main
-snb	Forum_hasTag_Tag	forum_hastag	false	Forum	[id]	[ForumId]	Tag	[id]	[TagId]	NULL	NULL	NULL	main
-snb	Forum_hasMember_Person	hasmember	false	Forum	[id]	[ForumId]	Person	[id]	[PersonId]	NULL	NULL	NULL	main
-snb	Person_knows_person	knows	false	Person	[id]	[Person1Id]	Person	[id]	[Person2Id]	NULL	NULL	NULL	main
+snb	Message	message	1	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	(empty)
+snb	City	city	1	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	(empty)
+snb	Country	country	1	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	(empty)
+snb	TagClass	tagclass	1	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	(empty)
+snb	Tag	tag	1	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	(empty)
+snb	Place	place	1	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	(empty)
+snb	Organisation	organisation	1	NULL	NULL	NULL	NULL	NULL	NULL	typemask	[company, university]	NULL	(empty)
+snb	Forum	forum	1	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	(empty)
+snb	Person	person	1	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	(empty)
+snb	Message_replyOf_Message	replyof	0	Message	[id]	[messageId]	Message	[id]	[ParentMessageId]	NULL	NULL	NULL	(empty)
+snb	Message_hasAuthor_Person	hasauthor	0	Message	[id]	[messageId]	Person	[id]	[PersonId]	NULL	NULL	NULL	(empty)
+snb	Message_hasTag_Tag	message_hastag	0	Message	[id]	[id]	Tag	[id]	[TagId]	NULL	NULL	NULL	(empty)
+snb	Person_likes_Message	likes_message	0	Person	[id]	[PersonId]	Message	[id]	[id]	NULL	NULL	NULL	(empty)
+snb	person_workAt_Organisation	workat_organisation	0	Person	[id]	[PersonId]	Organisation	[id]	[OrganisationId]	NULL	NULL	NULL	(empty)
+snb	Person_hasInterest_Tag	hasinterest	0	Person	[id]	[PersonId]	Tag	[id]	[TagId]	NULL	NULL	NULL	(empty)
+snb	Forum_hasTag_Tag	forum_hastag	0	Forum	[id]	[ForumId]	Tag	[id]	[TagId]	NULL	NULL	NULL	(empty)
+snb	Forum_hasMember_Person	hasmember	0	Forum	[id]	[ForumId]	Person	[id]	[PersonId]	NULL	NULL	NULL	(empty)
+snb	Person_knows_person	knows	0	Person	[id]	[Person1Id]	Person	[id]	[Person2Id]	NULL	NULL	NULL	(empty)
+
 
 statement error
 -DESCRIBE PROPERTY GRAPH pgdoesnotexist;
@@ -108,5 +109,5 @@ statement ok
 query IIIIIIIIIIIIII
 -DESCRIBE PROPERTY GRAPH bluesky;
 ----
-bluesky	account	account	true	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	bluesky	main
-bluesky	follows	follows	false	account	[did]	[source]	account	[did]	[destination]	NULL	NULL	bluesky	main
+bluesky	account	account	1	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	bluesky	(empty)
+bluesky	follows	follows	0	account	[did]	[source]	account	[did]	[destination]	NULL	NULL	bluesky	(empty)


### PR DESCRIPTION
Fixes #211 
Related PR: https://github.com/cwida/duckdb-pgq/pull/208

Before we didn't keep proper track of the catalog and schema for the vertex and edge tables. This PR is mostly error handling and making sure we track the correct catalog and schema for all table references in the create property graph statement. Before this PR we didn't keep proper track for the source and destination tables in the definition of an edge table. So this PR also expands the `__duckpgq_internal` table with new columns: source_catalog, source_schema, destination_catalog, destination_schema. 