### PR TITLE
Pragma create vertex table

### DIFF
--- a/src/core/pragma/CMakeLists.txt
+++ b/src/core/pragma/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(EXTENSION_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/create_vertex_table.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/show_property_graphs.cpp
         ${EXTENSION_SOURCES}
         PARENT_SCOPE

--- a/src/core/pragma/create_vertex_table.cpp
+++ b/src/core/pragma/create_vertex_table.cpp
@@ -1,0 +1,48 @@
+#include "duckdb/function/pragma_function.hpp"
+#include "duckdb/main/extension_util.hpp"
+#include <duckpgq/core/pragma/duckpgq_pragma.hpp>
+
+namespace duckpgq {
+
+    namespace core {
+
+        static string PragmaCreateVertexTable(ClientContext &context,
+                                               const FunctionParameters &parameters) {
+            if (parameters.values.size() != 4) {
+                throw InvalidInputException("PRAGMA create_vertex_table requires exactly four parameters: edge_table, source_column, destination_column, id_column_name");
+            }
+
+            string edge_table = parameters.values[0].GetValue<string>();
+            string source_column = parameters.values[1].GetValue<string>();
+            string destination_column = parameters.values[2].GetValue<string>();
+            string vertex_table_name = parameters.values[2].GetValue<string>();
+            string id_column_name = parameters.values[4].GetValue<string>();
+            // todo(dtenwolde) add some error handling
+
+            return "CREATE TABLE " + vertex_table_name + " AS "
+                   "SELECT DISTINCT " + source_column + " AS " + id_column_name + " FROM " + edge_table +
+                   " UNION ALL " +
+                   "SELECT DISTINCT " + destination_column + " AS " + id_column_name + " FROM " + edge_table;
+        }
+
+        void CorePGQPragma::RegisterCreateVertexTable(duckdb::DatabaseInstance &instance) {
+            // Define the pragma function
+            auto pragma_func = PragmaFunction::PragmaCall(
+                    "create_vertex_table",   // Name of the pragma
+                    PragmaCreateVertexTable, // Query substitution function
+                    {
+                        LogicalType::VARCHAR, // Edge table
+                        LogicalType::VARCHAR, // Source column
+                        LogicalType::VARCHAR, // Destination column
+                        LogicalType::VARCHAR, // Vertex table name todo(dtenwolde) make optional, default to vertex_table
+                        LogicalType::VARCHAR  // todo(dtenwolde) ID column name (should be optional, default ID)
+                    }                        // Parameter types (mail_limit is an integer)
+            );
+
+            // Register the pragma function
+            ExtensionUtil::RegisterFunction(instance, pragma_func);
+        }
+
+    } // namespace core
+
+} // namespace duckpgq

--- a/src/core/pragma/create_vertex_table.cpp
+++ b/src/core/pragma/create_vertex_table.cpp
@@ -8,21 +8,22 @@ namespace duckpgq {
 
         static string PragmaCreateVertexTable(ClientContext &context,
                                                const FunctionParameters &parameters) {
-            if (parameters.values.size() != 4) {
+            if (parameters.values.size() != 5) {
                 throw InvalidInputException("PRAGMA create_vertex_table requires exactly four parameters: edge_table, source_column, destination_column, id_column_name");
             }
 
             string edge_table = parameters.values[0].GetValue<string>();
             string source_column = parameters.values[1].GetValue<string>();
             string destination_column = parameters.values[2].GetValue<string>();
-            string vertex_table_name = parameters.values[2].GetValue<string>();
+            string vertex_table_name = parameters.values[3].GetValue<string>();
             string id_column_name = parameters.values[4].GetValue<string>();
             // todo(dtenwolde) add some error handling
 
-            return "CREATE TABLE " + vertex_table_name + " AS "
-                   "SELECT DISTINCT " + source_column + " AS " + id_column_name + " FROM " + edge_table +
+            return "CREATE TABLE " + vertex_table_name + " AS " +
+                   " SELECT DISTINCT " + id_column_name + " FROM " +
+                   "(SELECT DISTINCT " + source_column + " AS " + id_column_name + " FROM " + edge_table +
                    " UNION ALL " +
-                   "SELECT DISTINCT " + destination_column + " AS " + id_column_name + " FROM " + edge_table;
+                   "SELECT DISTINCT " + destination_column + " AS " + id_column_name + " FROM " + edge_table + ")";
         }
 
         void CorePGQPragma::RegisterCreateVertexTable(duckdb::DatabaseInstance &instance) {

--- a/src/core/pragma/create_vertex_table.cpp
+++ b/src/core/pragma/create_vertex_table.cpp
@@ -17,13 +17,13 @@ namespace duckpgq {
             string destination_column = parameters.values[2].GetValue<string>();
             string vertex_table_name = parameters.values[3].GetValue<string>();
             string id_column_name = parameters.values[4].GetValue<string>();
-            // todo(dtenwolde) add some error handling
 
-            return "CREATE TABLE " + vertex_table_name + " AS " +
-                   " SELECT DISTINCT " + id_column_name + " FROM " +
-                   "(SELECT DISTINCT " + source_column + " AS " + id_column_name + " FROM " + edge_table +
+            auto result_query = "CREATE TABLE " + vertex_table_name + " AS " +
+                   "SELECT DISTINCT " + id_column_name + " FROM " +
+                   "(SELECT " + source_column + " AS " + id_column_name + " FROM " + edge_table +
                    " UNION ALL " +
-                   "SELECT DISTINCT " + destination_column + " AS " + id_column_name + " FROM " + edge_table + ")";
+                   "SELECT " + destination_column + " AS " + id_column_name + " FROM " + edge_table + ")";
+            return result_query;
         }
 
         void CorePGQPragma::RegisterCreateVertexTable(duckdb::DatabaseInstance &instance) {
@@ -35,9 +35,9 @@ namespace duckpgq {
                         LogicalType::VARCHAR, // Edge table
                         LogicalType::VARCHAR, // Source column
                         LogicalType::VARCHAR, // Destination column
-                        LogicalType::VARCHAR, // Vertex table name todo(dtenwolde) make optional, default to vertex_table
-                        LogicalType::VARCHAR  // todo(dtenwolde) ID column name (should be optional, default ID)
-                    }                        // Parameter types (mail_limit is an integer)
+                        LogicalType::VARCHAR, // Vertex table name
+                        LogicalType::VARCHAR  // ID column name
+                    }
             );
 
             // Register the pragma function

--- a/src/include/duckpgq/core/pragma/duckpgq_pragma.hpp
+++ b/src/include/duckpgq/core/pragma/duckpgq_pragma.hpp
@@ -18,10 +18,12 @@ public:
   //! Register the PRAGMA function
   static void Register(DatabaseInstance &instance) {
     RegisterShowPropertyGraphs(instance);
+    RegisterCreateVertexTable(instance);
   }
 
 private:
   static void RegisterShowPropertyGraphs(DatabaseInstance &instance);
+  static void RegisterCreateVertexTable(DatabaseInstance &instance);
 };
 
 } // namespace core

--- a/test/sql/pragma/create_vertex_table.test
+++ b/test/sql/pragma/create_vertex_table.test
@@ -5,7 +5,6 @@
 
 require duckpgq
 
-
 statement ok
 CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (3,0, 13), (1,2, 14), (1,3, 15), (2,3, 16), (4,3, 17);
 
@@ -19,3 +18,50 @@ query I
 select count(*) from v; 
 ----
 5
+
+statement error
+pragma create_vertex_table(know, src, dst, group, id);
+----
+Parser Error: syntax error at or near "group"
+
+statement error
+pragma create_vertex_table(know, nonexistingcolumn, dst, v2, id);
+----
+Binder Error: Referenced column "nonexistingcolumn" not found in FROM clause!
+
+statement error
+pragma create_vertex_table(know, src, nonexistingcolumn, v3, id);
+----
+Binder Error: Referenced column "nonexistingcolumn" not found in FROM clause!
+
+statement error
+pragma create_vertex_table(nonexistingtable, src, dst, v3, id);
+----
+Catalog Error: Table with name nonexistingtable does not exist!
+
+statement error
+pragma create_vertex_table(know, src, dst, v, id);
+----
+Catalog Error: Table with name "v" already exists!
+
+statement error
+pragma create_vertex_table(know, src, dst, v);
+----
+Binder Error: No function matches the given name and argument types 'create_vertex_table(VARCHAR, VARCHAR, VARCHAR, VARCHAR)'. You might need to add explicit type casts.
+
+statement ok
+create table person_knows_person(creationDate, Person1id, Person2id) as from 'duckdb/data/SNB0.003/person_knows_person.csv';
+
+query I
+select count(*) from person_knows_person;
+----
+83
+
+statement ok
+pragma create_vertex_table(person_knows_person, person1id, person2id, v4, id);
+
+query I
+select count(*) from v4;
+----
+39
+

--- a/test/sql/pragma/create_vertex_table.test
+++ b/test/sql/pragma/create_vertex_table.test
@@ -1,0 +1,21 @@
+# name: test/sql/pragma/create_vertex_table.test
+# description: Testing the pragma create_vertex_table
+# group: [duckpgq_sql_pragma]
+
+
+require duckpgq
+
+
+statement ok
+CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (3,0, 13), (1,2, 14), (1,3, 15), (2,3, 16), (4,3, 17);
+
+statement ok
+pragma create_vertex_table(know, src, dst, v, id); 
+
+statement ok
+select * from v;
+
+query I 
+select count(*) from v; 
+----
+5


### PR DESCRIPTION
Fixes #57 

As a first implementation, this adds a pragma `create_vertex_table` that acts as a shorthand to create a vertex table from a given edge table. 
The pragma takes 5 arguments: 
* Edge table name
* Source column
* Destination column 
* Vertex table name
* ID column name (in vertex table)

The pragma executes the following query: 
```sql
CREATE TABLE v AS SELECT DISTINCT id FROM (SELECT src AS id FROM e UNION ALL SELECT dst AS id FROM e)
```
