### PR TITLE
Missing parameter for `create_vertex_table` pragma

### DIFF
--- a/src/core/pragma/create_vertex_table.cpp
+++ b/src/core/pragma/create_vertex_table.cpp
@@ -9,7 +9,7 @@ namespace duckpgq {
         static string PragmaCreateVertexTable(ClientContext &context,
                                                const FunctionParameters &parameters) {
             if (parameters.values.size() != 5) {
-                throw InvalidInputException("PRAGMA create_vertex_table requires exactly four parameters: edge_table, source_column, destination_column, id_column_name");
+                throw InvalidInputException("PRAGMA create_vertex_table requires exactly five parameters: edge_table, source_column, destination_column, vertex_table_name, id_column_name");
             }
 
             string edge_table = parameters.values[0].GetValue<string>();


### PR DESCRIPTION
Fixes #224

### Problem

The exception text mentions four required parameters, but there are five.

### Solution

Update the language to "five" and include the missing parameter name (`vertex_table_name`).