### PR TITLE
Fix not being able to return table as struct and star expressions

### DIFF
--- a/src/core/functions/table/match.cpp
+++ b/src/core/functions/table/match.cpp
@@ -1091,6 +1091,18 @@ void PGQMatchFunction::CheckColumnBinding(
     if (column_ref->column_names.back() == "rowid") {
       continue;
     }
+    if (column_ref->column_names.size() == 1) {
+      bool single_alias = false;
+      for (const auto &alias : alias_to_vertex_and_edge_tables) {
+        if (alias.first == column_ref->column_names[0]) {
+          single_alias = true;
+          break;
+        }
+      }
+      if (single_alias) {
+        continue;
+      }
+    }
     const auto cur_fq_col_name =
         StringUtil::Join(column_ref->column_names, /*separator=*/".");
     if (all_fq_col_names.find(cur_fq_col_name) == all_fq_col_names.end()) {

--- a/src/core/functions/table/match.cpp
+++ b/src/core/functions/table/match.cpp
@@ -93,10 +93,6 @@ vector<unique_ptr<ColumnRefExpression>> GetColRefExprFromPg(
   auto iter = alias_map.find(alias);
   D_ASSERT(iter != alias_map.end());
   const auto &tbl = iter->second;
-  // Skip edge table.
-  if (!tbl->is_vertex_table) {
-    return registered_col_names;
-  }
   registered_col_names.reserve(tbl->column_names.size());
   for (const auto &cur_col : tbl->column_names) {
     auto new_col_names = vector<string>{"", ""};
@@ -1213,12 +1209,10 @@ PGQMatchFunction::MatchBindReplace(ClientContext &context,
     // Handle StarExpression.
     auto *star_expression = dynamic_cast<StarExpression *>(expression.get());
     if (star_expression != nullptr) {
-      // Skip edge table columns.
       if (!star_expression->relation_name.empty()) {
         auto tbl_iter = alias_to_vertex_and_edge_tables.find(
             star_expression->relation_name);
-        if (tbl_iter != alias_to_vertex_and_edge_tables.end() &&
-            !tbl_iter->second->is_vertex_table) {
+        if (tbl_iter == alias_to_vertex_and_edge_tables.end()) {
           continue;
         }
       }

--- a/test/sql/create_pg/all_properties.test
+++ b/test/sql/create_pg/all_properties.test
@@ -104,3 +104,33 @@ query I
 {'id': 1, 'name': Tavneet}
 {'id': 1, 'name': Tavneet}
 {'id': 2, 'name': Gabor}
+
+query I
+-FROM GRAPH_TABLE (pg_only_id MATCH (p:Person)-[k:Knows]->(p2:Person) COLUMNS (k.*));
+----
+0
+0
+0
+1
+1
+2
+
+query II
+-FROM GRAPH_TABLE (pg_only_id MATCH (p:Person)-[k:Knows]->(p2:Person) COLUMNS (p.*, k.*));
+----
+0	0
+0	0
+0	0
+1	1
+1	1
+2	2
+
+query III
+-FROM GRAPH_TABLE (pg_only_id MATCH (p:Person)-[k:Knows]->(p2:Person));
+----
+0	1	0
+0	2	0
+0	3	0
+1	2	1
+1	3	1
+2	3	2

--- a/test/sql/create_pg/all_properties.test
+++ b/test/sql/create_pg/all_properties.test
@@ -126,11 +126,11 @@ query II
 2	2
 
 query III
--FROM GRAPH_TABLE (pg_only_id MATCH (p:Person)-[k:Knows]->(p2:Person));
+-SELECT id, src, id_1 FROM GRAPH_TABLE (pg_only_id MATCH (p:Person)-[k:Knows]->(p2:Person));
 ----
-0	1	0
-0	2	0
-0	3	0
-1	2	1
-1	3	1
-2	3	2
+1	0	0
+2	0	0
+3	0	0
+2	1	1
+3	1	1
+3	2	2

--- a/test/sql/create_pg/all_properties.test
+++ b/test/sql/create_pg/all_properties.test
@@ -124,13 +124,3 @@ query II
 1	1
 1	1
 2	2
-
-query III
--SELECT id, src, id_1 FROM GRAPH_TABLE (pg_only_id MATCH (p:Person)-[k:Knows]->(p2:Person));
-----
-1	0	0
-2	0	0
-3	0	0
-2	1	1
-3	1	1
-3	2	2

--- a/test/sql/create_pg/all_properties.test
+++ b/test/sql/create_pg/all_properties.test
@@ -45,6 +45,7 @@ VERTEX TABLES (
 EDGE TABLES (
     know    SOURCE KEY ( src ) REFERENCES Student ( id )
             DESTINATION KEY ( dst ) REFERENCES Student ( id )
+            PROPERTIES (src)
             LABEL Knows
     );
 
@@ -77,3 +78,29 @@ query III
 2	2	[2]
 2	3	[2, 3]
 3	3	[3]
+
+
+statement error
+-FROM GRAPH_TABLE (pg_only_id MATCH (p:Person)-[k:Knows]->(p2:Person) COLUMNS (dst));
+----
+Binder Error: Property dst is never registered!
+
+query I
+-FROM GRAPH_TABLE (pg_only_id MATCH (p:Person)-[k:Knows]->(p2:Person) COLUMNS (src));
+----
+0
+0
+0
+1
+1
+2
+
+query I
+-FROM GRAPH_TABLE (pg_only_id MATCH (p:Person)-[k:Knows]->(p2:Person) COLUMNS (p));
+----
+{'id': 0, 'name': Daniel}
+{'id': 0, 'name': Daniel}
+{'id': 0, 'name': Daniel}
+{'id': 1, 'name': Tavneet}
+{'id': 1, 'name': Tavneet}
+{'id': 2, 'name': Gabor}

--- a/test/sql/create_pg/attach_pg.test
+++ b/test/sql/create_pg/attach_pg.test
@@ -51,6 +51,10 @@ statement ok con1
             LABEL follows);
 
 statement ok con1
+SELECT * FROM bluesky.account;
+
+
+statement ok con1
 -FROM GRAPH_TABLE (bluesky MATCH (a:account));
 
 query I

--- a/test/sql/path_finding/shortest_path.test
+++ b/test/sql/path_finding/shortest_path.test
@@ -90,7 +90,7 @@ statement error
     COLUMNS (p, a.name as name, b.name as b_name)
     ) study;
 ----
-Binder Error: Property p is never registered
+Binder Error: Property p is never registered!
 
 
 query III

--- a/test/sql/pattern_matching/basic_match.test
+++ b/test/sql/pattern_matching/basic_match.test
@@ -305,5 +305,46 @@ query II
 2	Gabor
 4	David
 
+query I
+-FROM GRAPH_TABLE (pg
+    MATCH
+    (a:PERSON)-[k:knows]->(b:person)
+    COLUMNS (a)
+    ) study;
+----
+{'id': 0, 'name': Daniel}
+{'id': 0, 'name': Daniel}
+{'id': 0, 'name': Daniel}
+{'id': 3, 'name': Peter}
+{'id': 1, 'name': Tavneet}
+{'id': 1, 'name': Tavneet}
+{'id': 2, 'name': Gabor}
+{'id': 4, 'name': David}
+
+query III
+-FROM GRAPH_TABLE (pg
+    MATCH
+    (a:PERSON)-[k:knows]->(b:person)
+    COLUMNS (a, k, b)
+    ) study;
+----
+{'id': 0, 'name': Daniel}	{'src': 0, 'dst': 1, 'createDate': 10}	{'id': 1, 'name': Tavneet}
+{'id': 0, 'name': Daniel}	{'src': 0, 'dst': 2, 'createDate': 11}	{'id': 2, 'name': Gabor}
+{'id': 0, 'name': Daniel}	{'src': 0, 'dst': 3, 'createDate': 12}	{'id': 3, 'name': Peter}
+{'id': 3, 'name': Peter}	{'src': 3, 'dst': 0, 'createDate': 13}	{'id': 0, 'name': Daniel}
+{'id': 1, 'name': Tavneet}	{'src': 1, 'dst': 2, 'createDate': 14}	{'id': 2, 'name': Gabor}
+{'id': 1, 'name': Tavneet}	{'src': 1, 'dst': 3, 'createDate': 15}	{'id': 3, 'name': Peter}
+{'id': 2, 'name': Gabor}	{'src': 2, 'dst': 3, 'createDate': 16}	{'id': 3, 'name': Peter}
+{'id': 4, 'name': David}	{'src': 4, 'dst': 3, 'createDate': 17}	{'id': 3, 'name': Peter}
+
+statement error
+-FROM GRAPH_TABLE (pg
+    MATCH
+    (a:PERSON)-[k:knows]->(b:person)
+    COLUMNS (doesnotexist, k, b)
+    ) study;
+----
+Binder Error: Property doesnotexist is never registered!
+
 statement ok
 -DROP PROPERTY GRAPH pg;

--- a/test/sql/pattern_matching/inheritance_support.test
+++ b/test/sql/pattern_matching/inheritance_support.test
@@ -65,21 +65,21 @@ FROM GRAPH_TABLE(pg
 3	Peter	0	VU
 4	David	3	CWI
 
-query IIIII
+query IIIIIII
 -SELECT *
 FROM GRAPH_TABLE(pg
     MATCH (p:Person)-[w:worksAt]->(u:organisation)
     COLUMNS (p.*, u.*, w.*)
     ) result
 ----
-0	Daniel	1	1	UvA
-0	Daniel	2	2	EY
-0	Daniel	3	2	CWI
-1	Tavneet	2	2	EY
-1	Tavneet	3	2	CWI
-2	Gabor	3	2	CWI
-3	Peter	0	1	VU
-4	David	3	2	CWI
+0	Daniel	1	1	UvA	1	0
+0	Daniel	2	2	EY	2	0
+0	Daniel	3	2	CWI	3	0
+1	Tavneet	2	2	EY	2	1
+1	Tavneet	3	2	CWI	3	1
+2	Gabor	3	2	CWI	3	2
+3	Peter	0	1	VU	0	3
+4	David	3	2	CWI	3	4
 
 query IIIII
 -SELECT *


### PR DESCRIPTION
Fixes #228 

After introducing the restrictions on properties in the property graph creation, we have unintentionally lost some functionalities such as being able to return a table as a struct or returning all columns in a table using `alias.*`. This PR re-introduces those functionalities. Also not all properties of edge tables were returned, but not that functionality is restored as well. 

When querying `MATCH (p:Person) COLUMNS (p.*)`, we do keep in mind potential restrictions on the `Person` table defined during the property graph creation. So if `PROPERTIES (<subset of columns>)` was used, we return this subset of columns. 