### PR TITLE
fix: Imporve error msg, this error was also thrown when edge tables referred to non existent vertices

### DIFF
--- a/src/core/functions/scalar/csr_creation.cpp
+++ b/src/core/functions/scalar/csr_creation.cpp
@@ -138,8 +138,8 @@ static void CreateCsrEdgeFunction(DataChunk &args, ExpressionState &state,
   int64_t edge_size_count = args.data[3].GetValue(0).GetValue<int64_t>();
   if (edge_size != edge_size_count) {
     duckpgq_state->csr_to_delete.insert(info.id);
-    throw ConstraintException("Non-unique vertices detected. Make sure all "
-                              "vertices are unique for path-finding queries.");
+    throw ConstraintException("Non-existent/non-unique vertices detected. Make sure all "
+                              "vertices referred by edge tables exist and are unique for path-finding queries.");
   }
 
   auto csr_entry = duckpgq_state->csr_list.find(info.id);

--- a/test/sql/path_finding/non-unique-vertices.test
+++ b/test/sql/path_finding/non-unique-vertices.test
@@ -42,7 +42,7 @@ statement error
   COLUMNS (path_length(p), vertices(p), v2.x)
 );
 ----
-Constraint Error: Non-unique vertices detected. Make sure all vertices are unique for path-finding queries.
+Constraint Error: Non-existent/non-unique vertices detected. Make sure all vertices referred by edge tables exist and are unique for path-finding queries.
 
 # ANY SHORTEST v-[e]->{1,2}(v) also fails with "INTERNAL Error: Attempted to access index 1 within vector of size 1"
 statement error
@@ -51,7 +51,7 @@ statement error
   COLUMNS (path_length(p), vertices(p), v2.x)
 );
 ----
-Constraint Error: Non-unique vertices detected. Make sure all vertices are unique for path-finding queries.
+Constraint Error: Non-existent/non-unique vertices detected. Make sure all vertices referred by edge tables exist and are unique for path-finding queries.
 
 statement ok
 CREATE TABLE v2 (x VARCHAR);INSERT INTO v2 VALUES ('a'), ('b'), ('c'), ('c'), ('b');
@@ -77,9 +77,9 @@ statement error
   COLUMNS (path_length(p), vertices(p), v2.x)
 );
 ----
-Constraint Error: Non-unique vertices detected. Make sure all vertices are unique for path-finding queries.
+Constraint Error: Non-existent/non-unique vertices detected. Make sure all vertices referred by edge tables exist and are unique for path-finding queries.
 
 statement error
 from weakly_connected_component(g2, v2, e2);
 ----
-Constraint Error: Non-unique vertices detected. Make sure all vertices are unique for path-finding queries.
+Constraint Error: Non-existent/non-unique vertices detected. Make sure all vertices referred by edge tables exist and are unique for path-finding queries.


### PR DESCRIPTION
Ran into an issue where my edge table was referring to a non existent vertex, improved the error msg to highlight this scenario.