### PR TITLE
Fix SIGSEGV when using GRAPH_TABLE with UNION/EXCEPT/INTERSECT

### DIFF
--- a/src/core/parser/duckpgq_parser.cpp
+++ b/src/core/parser/duckpgq_parser.cpp
@@ -13,6 +13,7 @@
 #include <duckpgq_state.hpp>
 
 #include "duckdb/parser/query_node/cte_node.hpp"
+#include "duckdb/parser/query_node/set_operation_node.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include <duckpgq/core/functions/table/describe_property_graph.hpp>
 #include <duckpgq/core/functions/table/drop_property_graph.hpp>
@@ -60,23 +61,51 @@ void duckpgq_find_match_function(TableRef *table_ref, DuckPGQState &duckpgq_stat
 	}
 }
 
-ParserExtensionPlanResult duckpgq_find_select_statement(SQLStatement *statement, DuckPGQState &duckpgq_state) {
-	const auto select_statement = dynamic_cast<SelectStatement *>(statement);
-	auto node = dynamic_cast<SelectNode *>(select_statement->node.get());
-	CTENode *cte_node = nullptr;
+// Recursively traverse a QueryNode tree, finding and processing all MATCH expressions.
+// Handles SelectNode, CTENode, and SetOperationNode (UNION/INTERSECT/EXCEPT).
+static void duckpgq_traverse_query_node(QueryNode *query_node, DuckPGQState &duckpgq_state) {
+	if (!query_node) {
+		return;
+	}
 
-	// Check if node is not a SelectNode
-	if (!node) {
-		// Attempt to cast to CTENode
-		cte_node = dynamic_cast<CTENode *>(select_statement->node.get());
-		if (cte_node) {
-			// Get the child node as a SelectNode if cte_node is valid
-			node = dynamic_cast<SelectNode *>(cte_node->child.get());
+	// All QueryNode types can have CTEs — process them first
+	for (auto const &kv_pair : query_node->cte_map.map) {
+		auto const &cte = kv_pair.second;
+		auto *cte_select_statement = dynamic_cast<SelectStatement *>(cte->query.get());
+		if (cte_select_statement) {
+			duckpgq_traverse_query_node(cte_select_statement->node.get(), duckpgq_state);
 		}
 	}
 
-	// Check if node is a ShowRef
-	if (node) {
+	if (auto *select_node = dynamic_cast<SelectNode *>(query_node)) {
+		if (select_node->from_table) {
+			duckpgq_find_match_function(select_node->from_table.get(), duckpgq_state);
+		}
+	} else if (auto *cte_node = dynamic_cast<CTENode *>(query_node)) {
+		duckpgq_traverse_query_node(cte_node->child.get(), duckpgq_state);
+	} else if (auto *setop_node = dynamic_cast<SetOperationNode *>(query_node)) {
+		for (auto &child : setop_node->children) {
+			duckpgq_traverse_query_node(child.get(), duckpgq_state);
+		}
+	}
+}
+
+ParserExtensionPlanResult duckpgq_find_select_statement(SQLStatement *statement, DuckPGQState &duckpgq_state) {
+	const auto select_statement = dynamic_cast<SelectStatement *>(statement);
+	if (!select_statement) {
+		return {};
+	}
+	auto *query_node = select_statement->node.get();
+
+	// Check for ShowRef (DESCRIBE / SUMMARY property graph) — only applies to SelectNode
+	auto *node = dynamic_cast<SelectNode *>(query_node);
+	if (!node) {
+		auto *cte_node = dynamic_cast<CTENode *>(query_node);
+		if (cte_node) {
+			node = dynamic_cast<SelectNode *>(cte_node->child.get());
+		}
+	}
+	if (node && node->from_table) {
 		const auto describe_node = dynamic_cast<ShowRef *>(node->from_table.get());
 		if (describe_node) {
 			ParserExtensionPlanResult result;
@@ -95,38 +124,8 @@ ParserExtensionPlanResult duckpgq_find_select_statement(SQLStatement *statement,
 		}
 	}
 
-	CommonTableExpressionMap *cte_map = nullptr;
-	if (node) {
-		cte_map = &node->cte_map;
-	} else if (cte_node) {
-		cte_map = &cte_node->cte_map;
-	}
-
-	if (!cte_map) {
-		return {};
-	}
-
-	for (auto const &kv_pair : cte_map->map) {
-		auto const &cte = kv_pair.second;
-
-		auto *cte_select_statement = dynamic_cast<SelectStatement *>(cte->query.get());
-		if (!cte_select_statement) {
-			continue;
-		}
-
-		auto *select_node = dynamic_cast<SelectNode *>(cte_select_statement->node.get());
-		if (!select_node) {
-			continue; // The SelectStatement has no SelectNode, skip.
-		}
-
-		// If we get here, we know select_node is valid.
-		duckpgq_find_match_function(select_node->from_table.get(), duckpgq_state);
-	}
-	if (node) {
-		duckpgq_find_match_function(node->from_table.get(), duckpgq_state);
-	} else {
-		throw Exception(ExceptionType::INTERNAL, "node is a nullptr.");
-	}
+	// Recursively find and process all MATCH expressions in the query tree
+	duckpgq_traverse_query_node(query_node, duckpgq_state);
 	return {};
 }
 

--- a/test/sql/union_graph_table.test
+++ b/test/sql/union_graph_table.test
@@ -1,0 +1,81 @@
+# name: test/sql/union_graph_table.test
+# description: Regression test for UNION/EXCEPT with GRAPH_TABLE (fixes #249 and #276)
+# group: [sql]
+
+require duckpgq
+
+statement ok
+CREATE TABLE Student(id BIGINT, name VARCHAR);INSERT INTO Student VALUES (0, 'Daniel'), (1, 'Tavneet'), (2, 'Gabor'), (3, 'Peter'), (4, 'David');
+
+statement ok
+CREATE TABLE know(src BIGINT, dst BIGINT, createDate BIGINT);INSERT INTO know VALUES (0,1, 10), (0,2, 11), (0,3, 12), (3,0, 13), (1,2, 14), (1,3, 15), (2,3, 16), (4,3, 17);
+
+statement ok
+-CREATE PROPERTY GRAPH pg
+VERTEX TABLES (
+    Student
+    )
+EDGE TABLES (
+    know    SOURCE KEY ( src ) REFERENCES Student ( id )
+            DESTINATION KEY ( dst ) REFERENCES Student ( id )
+    );
+
+# UNION ALL of two GRAPH_TABLE queries (previously caused SIGSEGV)
+query I
+-FROM GRAPH_TABLE(pg MATCH (a:Student WHERE a.id = 0) COLUMNS (a.name))
+UNION ALL
+FROM GRAPH_TABLE(pg MATCH (a:Student WHERE a.id = 1) COLUMNS (a.name));
+----
+Daniel
+Tavneet
+
+# UNION (deduplicated)
+query I
+-FROM GRAPH_TABLE(pg MATCH (a:Student WHERE a.id = 0) COLUMNS (a.name))
+UNION
+FROM GRAPH_TABLE(pg MATCH (a:Student WHERE a.id = 0) COLUMNS (a.name));
+----
+Daniel
+
+# EXCEPT with GRAPH_TABLE
+query I
+-FROM GRAPH_TABLE(pg MATCH (a:Student) COLUMNS (a.name))
+EXCEPT
+FROM GRAPH_TABLE(pg MATCH (a:Student WHERE a.id = 0) COLUMNS (a.name));
+----
+David
+Gabor
+Peter
+Tavneet
+
+# CTE wrapping GRAPH_TABLE with UNION in outer query
+query I
+-WITH friends AS (
+    FROM GRAPH_TABLE(pg
+        MATCH (a:Student WHERE a.name = 'Daniel')-[k:know]->(b:Student)
+        COLUMNS (b.name)
+    )
+)
+SELECT * FROM friends
+UNION ALL
+FROM GRAPH_TABLE(pg MATCH (a:Student WHERE a.id = 4) COLUMNS (a.name));
+----
+Tavneet
+Gabor
+Peter
+David
+
+# Multiple CTEs both using GRAPH_TABLE
+query II
+-WITH cte1 AS (
+    FROM GRAPH_TABLE(pg MATCH (a:Student WHERE a.id = 0) COLUMNS (a.id, a.name))
+),
+cte2 AS (
+    FROM GRAPH_TABLE(pg MATCH (a:Student WHERE a.id = 1) COLUMNS (a.id, a.name))
+)
+SELECT * FROM cte1
+UNION ALL
+SELECT * FROM cte2;
+----
+0	Daniel
+1	Tavneet


### PR DESCRIPTION
## Problem

`duckpgq_find_select_statement()` in `duckpgq_parser.cpp` only handles `SelectNode` and `CTENode`. When a query uses `UNION ALL`, `EXCEPT`, or `INTERSECT` with `GRAPH_TABLE`, the top-level node is a `SetOperationNode`, which is not handled — leading to a null pointer dereference and SIGSEGV.

Reproduction (crashes on current main):
```sql
FROM GRAPH_TABLE(pg MATCH (a:Person) COLUMNS (a.name))
UNION ALL
FROM GRAPH_TABLE(pg MATCH (b:Person) COLUMNS (b.name));
```

## Solution

Add a recursive `duckpgq_traverse_query_node()` function that handles all `QueryNode` types:
- **`SelectNode`** → traverse `from_table` for MATCH functions
- **`CTENode`** → recurse into child node
- **`SetOperationNode`** → recurse into all children (UNION/EXCEPT/INTERSECT)

CTEs are processed at each level before descending, since all `QueryNode` types can have their own `cte_map`.

This is a minimal, targeted fix — only `duckpgq_parser.cpp` is changed.

## Test plan
- New test file `test/sql/union_graph_table.test` with 5 regression tests:
  - `UNION ALL` of two `GRAPH_TABLE` queries
  - `UNION` (deduplicated)
  - `EXCEPT` with `GRAPH_TABLE`
  - CTE wrapping `GRAPH_TABLE` + `UNION` in outer query
  - Multiple CTEs both using `GRAPH_TABLE` combined with `UNION ALL`

Fixes #249
Fixes #276