### PR TITLE
Fix LOAD segfault on DuckDB v1.5.1 community build (#305)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,6 @@ cmake_minimum_required(VERSION 3.5)
 set(TARGET_NAME duckpgq)
 set(CMAKE_CXX_STANDARD 11)
 
-# DuckDB's extension distribution supports vcpkg. As such, dependencies can be
-# added in ./vcpkg.json and then used in cmake with find_package. Feel free to
-# remove or replace with other dependencies. Note that it should also be removed
-# from vcpkg.json to prevent needlessly installing it..
-find_package(OpenSSL REQUIRED)
-
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
@@ -19,10 +13,6 @@ include_directories(../duckdb/third_party/libpg_query/include)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
-
-# Link OpenSSL in both the static library as the loadable extension
-target_link_libraries(${EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto)
-target_link_libraries(${LOADABLE_EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto)
 
 install(
   TARGETS ${EXTENSION_NAME}

--- a/src/core/operator/duckpgq_bind.cpp
+++ b/src/core/operator/duckpgq_bind.cpp
@@ -4,8 +4,7 @@
 #include <duckpgq/core/parser/duckpgq_parser.hpp>
 #include "duckpgq/core/operator/duckpgq_operator.hpp"
 #include <duckpgq_state.hpp>
-#include "duckdb/main/extension_callback_manager.hpp"
-
+#include "duckdb/main/config.hpp"
 #include "duckdb/planner/operator_extension.hpp"
 
 namespace duckdb {
@@ -30,8 +29,8 @@ BoundStatement duckpgq_bind(ClientContext &context, Binder &binder, OperatorExte
 //------------------------------------------------------------------------------
 void CorePGQOperator::RegisterPGQBindOperator(ExtensionLoader &loader) {
 	auto &db = loader.GetDatabaseInstance();
-	auto &manager = ExtensionCallbackManager::Get(db);
-	manager.Register(make_shared_ptr<DuckPGQOperatorExtension>());
+	auto &config = DBConfig::GetConfig(db);
+	OperatorExtension::Register(config, make_shared_ptr<DuckPGQOperatorExtension>());
 }
 
 } // namespace duckdb

--- a/src/core/parser/duckpgq_parser.cpp
+++ b/src/core/parser/duckpgq_parser.cpp
@@ -21,7 +21,7 @@
 #include <duckdb/parser/tableref/matchref.hpp>
 #include <duckpgq/core/functions/table/summarize_property_graph.hpp>
 
-#include "duckdb/main/extension_callback_manager.hpp"
+#include "duckdb/main/config.hpp"
 #include "duckdb/parser/query_node/insert_query_node.hpp"
 #include "duckpgq/core/utils/duckpgq_utils.hpp"
 
@@ -218,8 +218,8 @@ ParserExtensionPlanResult duckpgq_plan(ParserExtensionInfo *, ClientContext &con
 //------------------------------------------------------------------------------
 void CorePGQParser::RegisterPGQParserExtension(ExtensionLoader &loader) {
 	auto &db = loader.GetDatabaseInstance();
-	auto &manager = ExtensionCallbackManager::Get(db);
-	manager.Register(DuckPGQParserExtension());
+	auto &config = DBConfig::GetConfig(db);
+	ParserExtension::Register(config, DuckPGQParserExtension());
 }
 
 } // namespace duckdb

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,5 @@
 {
-        "dependencies": [
-                "openssl"
-        ],
+        "dependencies": [],
         "vcpkg-configuration": {
                 "overlay-ports": [
                         "./extension-ci-tools/vcpkg_ports"


### PR DESCRIPTION
## Summary

- Replace direct `ExtensionCallbackManager::Get(db).Register()` calls with `DBConfig::GetConfig(db)` + static `ParserExtension::Register()` / `OperatorExtension::Register()` to avoid ABI issues in community builds where the extension's static DuckDB copy accesses host data structures
- Remove unused OpenSSL dependency (inherited from extension template, never actually used in source code)
- Point `duckdb` submodule to the exact `v1.5.1` tag (`f7f679eb`) instead of `31d179b1` (v1.5.2-dev1)

## Root Cause Analysis

The community extension binary is built with `EXTENSION_STATIC_BUILD=1`, which statically links a full copy of DuckDB into the extension. When the extension calls `ExtensionCallbackManager::Get(db).Register(ParserExtension)`, it uses its **own static copy** of the `Register` function to operate on the **host DuckDB's** `ExtensionCallbackManager` data structures.

The `Register(ParserExtension)` function internally copies the entire `ExtensionCallbackRegistry` (which contains vectors of extension objects). This copy operation, performed by the extension's code on the host's data, can fail when the two binaries were compiled under different environments (the official DuckDB binary is built on manylinux_2_28 with GCC 8.5/14.2, while the community extension is built separately).

This manifests as:
- **macOS**: `"vector"` exception (from `std::vector::at()` in libc++)
- **Linux**: SIGSEGV at `si_addr=NULL` (null pointer dereference) or `"basic_string::_M_create"` exception

The fix uses `DBConfig::GetConfig(db)` (which is `DUCKDB_API`) combined with the static `Register` methods, which is the idiomatic pattern for extension registration.

Fixes #305

## Test plan

- [x] All 60 existing tests pass locally
- [x] Extension loads successfully via `LOAD` in local build
- [ ] Verify community build loads without crash on DuckDB v1.5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)