### PR TITLE
Deduplicate self-loop edges in undirected pattern matching

### DIFF
--- a/src/core/functions/table/match.cpp
+++ b/src/core/functions/table/match.cpp
@@ -376,7 +376,11 @@ void PGQMatchFunction::EdgeTypeAny(const shared_ptr<PropertyGraphTable> &edge_ta
 	      << DuckPGQSQL::Identifier(edge_table->source_fk[0]) << ", "
 	      << DuckPGQSQL::Column(edge_table->source_fk[0], edge_binding) << " AS "
 	      << DuckPGQSQL::Identifier(edge_table->destination_fk[0]) << ", * FROM "
-	      << DuckPGQSQL::TableRef(*edge_table, edge_binding);
+	      << DuckPGQSQL::TableRef(*edge_table, edge_binding)
+	      // A self-loop (src = dst) binds identically in both orientations, so the
+	      // reversed arm must skip it to return it exactly once (issue #314).
+	      << " WHERE " << DuckPGQSQL::Column(edge_table->source_fk[0], edge_binding) << " <> "
+	      << DuckPGQSQL::Column(edge_table->destination_fk[0], edge_binding);
 	PGQAppendCrossJoin(from_clause, DuckPGQSQL::ParseSubqueryRef(query.str(), edge_binding));
 	// (a) src.key = edge.src
 	auto src_left_expr =

--- a/test/sql/pattern_matching/undirected_self_loop.test
+++ b/test/sql/pattern_matching/undirected_self_loop.test
@@ -1,0 +1,53 @@
+# name: test/sql/pattern_matching/undirected_self_loop.test
+# description: Self-loop edges must bind exactly once in undirected edge patterns (issue #314)
+# group: [pattern_matching]
+
+require duckpgq
+
+statement ok
+CREATE TABLE Person(id BIGINT, name VARCHAR);INSERT INTO Person VALUES (0, 'Ana'), (1, 'Bob');
+
+statement ok
+CREATE TABLE knows(src BIGINT, dst BIGINT);INSERT INTO knows VALUES (1, 1), (0, 1);
+
+statement ok
+CREATE PROPERTY GRAPH selfloop_pg
+VERTEX TABLES (
+    Person
+    )
+EDGE TABLES (
+    knows   SOURCE KEY ( src ) REFERENCES Person ( id )
+            DESTINATION KEY ( dst ) REFERENCES Person ( id )
+    );
+
+# The regular edge (0,1) binds once per orientation; the self-loop (1,1) binds
+# identically in both orientations, so it must appear exactly once.
+query II
+SELECT a_id, b_id FROM GRAPH_TABLE (selfloop_pg
+    MATCH (a:Person)-[k:knows]-(b:Person)
+    COLUMNS (a.id AS a_id, b.id AS b_id)
+    ) ORDER BY a_id, b_id;
+----
+0	1
+1	0
+1	1
+
+# Same with distinct variable names for both endpoints (issue #314 comment).
+query II
+SELECT p_id, p2_id FROM GRAPH_TABLE (selfloop_pg
+    MATCH (p:Person)-[k:knows]-(p2:Person)
+    WHERE p.id = 1 AND p2.id = 1
+    COLUMNS (p.id AS p_id, p2.id AS p2_id)
+    ) ORDER BY p_id, p2_id;
+----
+1	1
+
+# Directed matching is unaffected.
+query II
+SELECT a_id, b_id FROM GRAPH_TABLE (selfloop_pg
+    MATCH (a:Person)-[k:knows]->(b:Person)
+    COLUMNS (a.id AS a_id, b.id AS b_id)
+    ) ORDER BY a_id, b_id;
+----
+0	1
+1	1


### PR DESCRIPTION
**Summary**
Undirected edge patterns ((a)-[e]-(b)) returned self-loop edges (src = dst) twice. This makes them bind exactly once, per SQL/PGQ semantics. Fixes [#314](https://github.com/strattum-ai/strattum/issues/314)

**Problem**
EdgeTypeAny rewrites an undirected edge as the edge table UNION ALL its reversed projection. A self-loop row is identical in both arms, so the match emits a duplicate binding:

```
CREATE TABLE Person(id BIGINT); INSERT INTO Person VALUES (0),(1);
CREATE TABLE knows(src BIGINT, dst BIGINT); INSERT INTO knows VALUES (1,1),(0,1);
-- MATCH (a:Person)-[k:knows]-(b:Person)
-- before: (0,1), (1,0), (1,1), (1,1)   ← self-loop twice
-- after:  (0,1), (1,0), (1,1)
```

**Fix**
Filter self-loops out of the reversed arm of the UNION ALL in EdgeTypeAny (4 lines). Regular edges still bind once per orientation; directed matching is untouched; variable-length paths are unaffected (the undirected CSR already deduplicates via GROUP BY src, dst).

**Test**
New test/sql/pattern_matching/undirected_self_loop.test — self-loop binds once (shared and distinct endpoint variables), directed matching unchanged. Full SQL suite: 63/63 test cases, 4134 assertions passing.