### PR TITLE
Avoid duplicate self loops

### DIFF
--- a/src/core/functions/table/create_property_graph.cpp
+++ b/src/core/functions/table/create_property_graph.cpp
@@ -58,6 +58,18 @@ static void ThrowMissingVertexReference(CreatePropertyGraphInfo &info, const Ide
 	info.GetTableByName(catalog_name.GetIdentifierName(), schema_name.GetIdentifierName(), table_name.GetIdentifierName());
 }
 
+static vector<Identifier> ExpandAllColumnsExcept(vector<string> column_names, const vector<Identifier> &except_columns) {
+	auto excluded_columns = IdentifiersToStrings(except_columns);
+	vector<string> selected_columns;
+
+	// Preserve the historical output order for expanded property columns.
+	std::sort(column_names.begin(), column_names.end());
+	std::sort(excluded_columns.begin(), excluded_columns.end());
+	std::set_difference(column_names.begin(), column_names.end(), excluded_columns.begin(), excluded_columns.end(),
+	                    std::back_inserter(selected_columns));
+	return StringsToIdentifiers(selected_columns);
+}
+
 void CreatePropertyGraphFunction::CheckPropertyGraphTableLabels(const shared_ptr<PropertyGraphTable> &pg_table,
                                                                 optional_ptr<TableCatalogEntry> &table) {
 	if (!pg_table->discriminator.empty()) {
@@ -88,13 +100,7 @@ void CreatePropertyGraphFunction::CheckPropertyGraphTableColumns(const shared_pt
 			}
 		}
 
-		auto columns_of_table = StringsToIdentifiers(table->GetColumns().GetColumnNames());
-
-		std::sort(std::begin(columns_of_table), std::end(columns_of_table));
-		std::sort(std::begin(pg_table->except_columns), std::end(pg_table->except_columns));
-		std::set_difference(columns_of_table.begin(), columns_of_table.end(), pg_table->except_columns.begin(),
-		                    pg_table->except_columns.end(),
-		                    std::inserter(pg_table->column_names, pg_table->column_names.begin()));
+		pg_table->column_names = ExpandAllColumnsExcept(table->GetColumns().GetColumnNames(), pg_table->except_columns);
 		pg_table->column_aliases = pg_table->column_names;
 		return;
 	}

--- a/src/core/functions/table/create_property_graph.cpp
+++ b/src/core/functions/table/create_property_graph.cpp
@@ -55,10 +55,12 @@ static optional_ptr<CatalogEntry> GetPropertyGraphView(ClientContext &context,
 
 static void ThrowMissingVertexReference(CreatePropertyGraphInfo &info, const Identifier &catalog_name,
                                         const Identifier &schema_name, const Identifier &table_name) {
-	info.GetTableByName(catalog_name.GetIdentifierName(), schema_name.GetIdentifierName(), table_name.GetIdentifierName());
+	info.GetTableByName(catalog_name.GetIdentifierName(), schema_name.GetIdentifierName(),
+	                    table_name.GetIdentifierName());
 }
 
-static vector<Identifier> ExpandAllColumnsExcept(vector<string> column_names, const vector<Identifier> &except_columns) {
+static vector<Identifier> ExpandAllColumnsExcept(vector<string> column_names,
+                                                 const vector<Identifier> &except_columns) {
 	auto excluded_columns = IdentifiersToStrings(except_columns);
 	vector<string> selected_columns;
 

--- a/src/core/functions/table/create_property_graph.cpp
+++ b/src/core/functions/table/create_property_graph.cpp
@@ -17,20 +17,24 @@ static Identifier PGQIdentifier(const string &value) {
 	return Identifier(value);
 }
 
-static void BindPropertyGraphTable(ClientContext &context, const shared_ptr<PropertyGraphTable> &table) {
-	auto catalog = PGQIdentifier(table->catalog_name);
-	auto schema = PGQIdentifier(table->schema_name);
-	Binder::BindSchemaOrCatalog(context, catalog, schema);
-	table->catalog_name = catalog.GetIdentifierName();
-	table->schema_name = schema.GetIdentifierName();
+static Identifier PGQIdentifier(const Identifier &value) {
+	return value;
 }
 
-static void BindPropertyGraphReference(ClientContext &context, string &catalog_name, string &schema_name) {
-	auto catalog = PGQIdentifier(catalog_name);
-	auto schema = PGQIdentifier(schema_name);
+static void BindPropertyGraphTable(ClientContext &context, const shared_ptr<PropertyGraphTable> &table) {
+	auto catalog = table->catalog_name;
+	auto schema = table->schema_name;
 	Binder::BindSchemaOrCatalog(context, catalog, schema);
-	catalog_name = catalog.GetIdentifierName();
-	schema_name = schema.GetIdentifierName();
+	table->catalog_name = catalog;
+	table->schema_name = schema;
+}
+
+static void BindPropertyGraphReference(ClientContext &context, Identifier &catalog_name, Identifier &schema_name) {
+	auto catalog = catalog_name;
+	auto schema = schema_name;
+	Binder::BindSchemaOrCatalog(context, catalog, schema);
+	catalog_name = catalog;
+	schema_name = schema;
 }
 
 static optional_ptr<TableCatalogEntry> GetPropertyGraphTable(ClientContext &context,
@@ -49,9 +53,9 @@ static optional_ptr<CatalogEntry> GetPropertyGraphView(ClientContext &context,
 	                        PGQIdentifier(table->table_name), OnEntryNotFound::RETURN_NULL);
 }
 
-static void ThrowMissingVertexReference(CreatePropertyGraphInfo &info, const string &catalog_name,
-                                        const string &schema_name, const string &table_name) {
-	info.GetTableByName(catalog_name, schema_name, table_name);
+static void ThrowMissingVertexReference(CreatePropertyGraphInfo &info, const Identifier &catalog_name,
+                                        const Identifier &schema_name, const Identifier &table_name) {
+	info.GetTableByName(catalog_name.GetIdentifierName(), schema_name.GetIdentifierName(), table_name.GetIdentifierName());
 }
 
 void CreatePropertyGraphFunction::CheckPropertyGraphTableLabels(const shared_ptr<PropertyGraphTable> &pg_table,
@@ -84,7 +88,7 @@ void CreatePropertyGraphFunction::CheckPropertyGraphTableColumns(const shared_pt
 			}
 		}
 
-		auto columns_of_table = table->GetColumns().GetColumnNames();
+		auto columns_of_table = StringsToIdentifiers(table->GetColumns().GetColumnNames());
 
 		std::sort(std::begin(columns_of_table), std::end(columns_of_table));
 		std::sort(std::begin(pg_table->except_columns), std::end(pg_table->except_columns));
@@ -103,9 +107,9 @@ void CreatePropertyGraphFunction::CheckPropertyGraphTableColumns(const shared_pt
 }
 
 // Helper function to validate source/destination keys
-void CreatePropertyGraphFunction::ValidateKeys(shared_ptr<PropertyGraphTable> &edge_table, const string &reference,
-                                               const string &key_type, vector<string> &pk_columns,
-                                               vector<string> &fk_columns,
+void CreatePropertyGraphFunction::ValidateKeys(shared_ptr<PropertyGraphTable> &edge_table, const Identifier &reference,
+                                               const string &key_type, vector<Identifier> &pk_columns,
+                                               vector<Identifier> &fk_columns,
                                                const vector<unique_ptr<Constraint>> &table_constraints) {
 	// todo(dtenwolde) add test case for attached databases or different schema that has pk-fk relationships
 	if (fk_columns.empty() && pk_columns.empty()) {
@@ -134,8 +138,8 @@ void CreatePropertyGraphFunction::ValidateKeys(shared_ptr<PropertyGraphTable> &e
 					                                            " KEY <primary key> REFERENCES " + reference +
 					                                            " <foreign key>`");
 				}
-				pk_columns = IdentifiersToStrings(fk_constraint.pk_columns);
-				fk_columns = IdentifiersToStrings(fk_constraint.fk_columns);
+				pk_columns = fk_constraint.pk_columns;
+				fk_columns = fk_constraint.fk_columns;
 			}
 		}
 
@@ -154,7 +158,7 @@ void CreatePropertyGraphFunction::ValidateKeys(shared_ptr<PropertyGraphTable> &e
 }
 
 void CreatePropertyGraphFunction::ValidateForeignKeyColumns(shared_ptr<PropertyGraphTable> &edge_table,
-                                                            const vector<string> &fk_columns,
+                                                            const vector<Identifier> &fk_columns,
                                                             optional_ptr<TableCatalogEntry> &table) {
 	for (const auto &fk : fk_columns) {
 		if (!table->ColumnExists(PGQIdentifier(fk))) {
@@ -176,7 +180,7 @@ void CreatePropertyGraphFunction::ValidateVertexTableRegistration(shared_ptr<Pro
 // Helper function to validate primary keys in the source or destination tables
 void CreatePropertyGraphFunction::ValidatePrimaryKeyInTable(ClientContext &context,
                                                             shared_ptr<PropertyGraphTable> &pg_table,
-                                                            const vector<string> &pk_columns) {
+                                                            const vector<Identifier> &pk_columns) {
 	auto table = GetPropertyGraphTable(context, pg_table);
 	if (!table) {
 		throw Exception(ExceptionType::INVALID, "Table with name " + pg_table->table_name + " does not exist");
@@ -238,7 +242,7 @@ unique_ptr<FunctionData> CreatePropertyGraphFunction::CreatePropertyGraphBind(Cl
 		}
 		v_table_names.insert(vertex_table->FullTableName());
 		if (vertex_table->hasTableNameAlias()) {
-			v_table_names.insert(vertex_table->table_name_alias);
+			v_table_names.insert(vertex_table->table_name_alias.GetIdentifierName());
 		}
 	}
 

--- a/src/core/functions/table/match.cpp
+++ b/src/core/functions/table/match.cpp
@@ -36,12 +36,20 @@ static Identifier PGQIdentifier(const string &value) {
 	return Identifier(value);
 }
 
+static Identifier PGQIdentifier(const Identifier &value) {
+	return value;
+}
+
 static void SetExpressionAlias(ParsedExpression &expr, const string &alias) {
 	expr.SetAlias(PGQIdentifier(alias));
 }
 
 static unique_ptr<ColumnRefExpression> PGQColumnRef(const string &column_name, const string &table_name) {
 	return make_uniq<ColumnRefExpression>(PGQIdentifier(column_name), PGQIdentifier(table_name));
+}
+
+static unique_ptr<ColumnRefExpression> PGQColumnRef(const Identifier &column_name, const string &table_name) {
+	return make_uniq<ColumnRefExpression>(column_name, PGQIdentifier(table_name));
 }
 
 static unique_ptr<ColumnRefExpression> PGQColumnRef(const string &table_name, const string &column_name,
@@ -53,8 +61,16 @@ static unique_ptr<ColumnRefExpression> PGQColumnRef(const string &table_name, co
 	return make_uniq<ColumnRefExpression>(std::move(column_names));
 }
 
+static unique_ptr<ColumnRefExpression> PGQColumnRef(const string &table_name, const Identifier &column_name,
+                                                    bool qualified) {
+	vector<Identifier> column_names;
+	column_names.push_back(PGQIdentifier(table_name));
+	column_names.push_back(column_name);
+	return make_uniq<ColumnRefExpression>(std::move(column_names));
+}
+
 static string DuckPGQSQLCountTable(const PropertyGraphTable &table, const string &table_alias,
-                                   const string &primary_key) {
+                                   const Identifier &primary_key) {
 	std::ostringstream query;
 	query << "SELECT count(" << DuckPGQSQL::Column(primary_key, table_alias) << ") FROM "
 	      << DuckPGQSQL::TableRef(table, table_alias);
@@ -193,18 +209,18 @@ void PopulateFullyQualifiedColName(const vector<shared_ptr<PropertyGraphTable>> 
 	for (const auto &cur_tbl : tbls) {
 		for (const auto &cur_col : cur_tbl->column_names) {
 			// It's legal to query by `<col>` instead of `<table>.<col>`.
-			col_names.insert(cur_col);
+			col_names.insert(cur_col.GetIdentifierName());
 
-			const string &tbl_name = cur_tbl->table_name;
+			const auto &tbl_name = cur_tbl->table_name.GetIdentifierName();
 			auto iter = tbl_name_to_aliases.find(tbl_name);
 			// Prefer to use table alias specified in the statement, otherwise use
 			// table name.
 			if (iter == tbl_name_to_aliases.end()) {
-				col_names.insert(StringUtil::Format("%s.%s", tbl_name, cur_col));
+				col_names.insert(StringUtil::Format("%s.%s", tbl_name, cur_col.GetIdentifierName()));
 			} else {
 				const auto &all_aliases = iter->second;
 				for (const auto &cur_alias : all_aliases) {
-					col_names.insert(StringUtil::Format("%s.%s", cur_alias, cur_col));
+					col_names.insert(StringUtil::Format("%s.%s", cur_alias, cur_col.GetIdentifierName()));
 				}
 			}
 		}
@@ -217,7 +233,7 @@ GetFullyQualifiedColFromPg(const CreatePropertyGraphInfo &pg,
                            const case_insensitive_map_t<shared_ptr<PropertyGraphTable>> &alias_map) {
 	case_insensitive_map_t<vector<string>> relation_name_to_aliases;
 	for (const auto &entry : alias_map) {
-		relation_name_to_aliases[entry.second->table_name].emplace_back(entry.first);
+		relation_name_to_aliases[entry.second->table_name.GetIdentifierName()].emplace_back(entry.first);
 	}
 
 	case_insensitive_set_t col_names;
@@ -267,9 +283,9 @@ bool IsSameGraphVertexReference(const PropertyGraphTable &edge_table) {
 		return edge_table.source_pg_table && edge_table.destination_pg_table &&
 		       edge_table.source_pg_table->SameTableIdentity(*edge_table.destination_pg_table);
 	}
-	return Identifier(edge_table.source_catalog) == Identifier(edge_table.destination_catalog) &&
-	       Identifier(edge_table.source_schema) == Identifier(edge_table.destination_schema) &&
-	       Identifier(edge_table.source_reference) == Identifier(edge_table.destination_reference);
+	return edge_table.source_catalog == edge_table.destination_catalog &&
+	       edge_table.source_schema == edge_table.destination_schema &&
+	       edge_table.source_reference == edge_table.destination_reference;
 }
 
 string CreateReverseSelfLoopFilter(const PropertyGraphTable &edge_table, const string &edge_binding) {
@@ -280,7 +296,7 @@ string CreateReverseSelfLoopFilter(const PropertyGraphTable &edge_table, const s
 	vector<string> equality_conditions;
 	for (idx_t source_idx = 0; source_idx < edge_table.source_pk.size(); source_idx++) {
 		for (idx_t destination_idx = 0; destination_idx < edge_table.destination_pk.size(); destination_idx++) {
-			if (Identifier(edge_table.source_pk[source_idx]) != Identifier(edge_table.destination_pk[destination_idx])) {
+			if (edge_table.source_pk[source_idx] != edge_table.destination_pk[destination_idx]) {
 				continue;
 			}
 			equality_conditions.push_back(DuckPGQSQL::Column(edge_table.source_fk[source_idx], edge_binding) +
@@ -311,15 +327,17 @@ shared_ptr<PropertyGraphTable> PGQMatchFunction::FindGraphTable(const string &la
 
 void PGQMatchFunction::CheckInheritance(const shared_ptr<PropertyGraphTable> &tableref, PathElement *element,
                                         vector<unique_ptr<ParsedExpression>> &conditions) {
-	if (StringUtil::CIEquals(tableref->main_label, element->label)) {
+	if (tableref->main_label == element->label) {
 		return;
 	}
 	if (tableref->discriminator.empty()) {
-		throw BinderException("Label %s is not a sublabel of %s", element->label, tableref->main_label);
+		throw BinderException("Label %s is not a sublabel of %s", element->label,
+		                      tableref->main_label.GetIdentifierName());
 	}
 	const auto itr = std::find(tableref->sub_labels.begin(), tableref->sub_labels.end(), element->label);
 	if (itr == tableref->sub_labels.end()) {
-		throw BinderException("Label %s is not a sublabel of %s", element->label, tableref->main_label);
+		throw BinderException("Label %s is not a sublabel of %s", element->label,
+		                      tableref->main_label.GetIdentifierName());
 	}
 
 	const auto idx_of_label = std::distance(tableref->sub_labels.begin(), itr);
@@ -329,22 +347,22 @@ void PGQMatchFunction::CheckInheritance(const shared_ptr<PropertyGraphTable> &ta
 	conditions.push_back(DuckPGQSQL::ParseExpression(condition.str()));
 }
 
-void PGQMatchFunction::CheckEdgeTableConstraints(const string &src_reference, const string &dst_reference,
+void PGQMatchFunction::CheckEdgeTableConstraints(const Identifier &src_reference, const Identifier &dst_reference,
                                                  const shared_ptr<PropertyGraphTable> &edge_table) {
 	if (src_reference != edge_table->source_reference) {
 		throw BinderException("Label %s is not registered as a source reference "
 		                      "for edge pattern of table %s",
-		                      src_reference, edge_table->table_name);
+		                      src_reference.GetIdentifierName(), edge_table->table_name.GetIdentifierName());
 	}
 	if (dst_reference != edge_table->destination_reference) {
 		throw BinderException("Label %s is not registered as a destination "
 		                      "reference for edge pattern of table %s",
-		                      src_reference, edge_table->table_name);
+		                      dst_reference.GetIdentifierName(), edge_table->table_name.GetIdentifierName());
 	}
 }
 
-unique_ptr<ParsedExpression> PGQMatchFunction::CreateMatchJoinExpression(vector<string> vertex_keys,
-                                                                         vector<string> edge_keys,
+unique_ptr<ParsedExpression> PGQMatchFunction::CreateMatchJoinExpression(vector<Identifier> vertex_keys,
+                                                                         vector<Identifier> edge_keys,
                                                                          const string &vertex_alias,
                                                                          const string &edge_alias) {
 	vector<unique_ptr<ParsedExpression>> conditions;
@@ -425,8 +443,8 @@ void PGQMatchFunction::EdgeTypeAny(const shared_ptr<PropertyGraphTable> &edge_ta
 	conditions.push_back(std::move(combined_left_expr));
 }
 
-void PGQMatchFunction::EdgeTypeLeft(const shared_ptr<PropertyGraphTable> &edge_table, const string &next_table_name,
-                                    const string &prev_table_name, const string &edge_binding,
+void PGQMatchFunction::EdgeTypeLeft(const shared_ptr<PropertyGraphTable> &edge_table, const Identifier &next_table_name,
+                                    const Identifier &prev_table_name, const string &edge_binding,
                                     const string &prev_binding, const string &next_binding,
                                     vector<unique_ptr<ParsedExpression>> &conditions) {
 	CheckEdgeTableConstraints(next_table_name, prev_table_name, edge_table);
@@ -436,9 +454,9 @@ void PGQMatchFunction::EdgeTypeLeft(const shared_ptr<PropertyGraphTable> &edge_t
 	    CreateMatchJoinExpression(edge_table->destination_pk, edge_table->destination_fk, prev_binding, edge_binding));
 }
 
-void PGQMatchFunction::EdgeTypeRight(const shared_ptr<PropertyGraphTable> &edge_table, const string &next_table_name,
-                                     const string &prev_table_name, const string &edge_binding,
-                                     const string &prev_binding, const string &next_binding,
+void PGQMatchFunction::EdgeTypeRight(const shared_ptr<PropertyGraphTable> &edge_table,
+                                     const Identifier &next_table_name, const Identifier &prev_table_name,
+                                     const string &edge_binding, const string &prev_binding, const string &next_binding,
                                      vector<unique_ptr<ParsedExpression>> &conditions) {
 	CheckEdgeTableConstraints(prev_table_name, next_table_name, edge_table);
 	conditions.push_back(
@@ -511,10 +529,10 @@ PGQMatchFunction::GenerateShortestPathCTE(CreatePropertyGraphInfo &pg_table, Sub
 	query << "SELECT shortestpath(0, ("
 	      << DuckPGQSQLCountTable(*edge_table->source_pg_table, previous_vertex_element->variable_binding,
 	                              edge_table->source_pk[0])
-	      << "), " << DuckPGQSQL::Column("rowid", previous_vertex_element->variable_binding) << ", "
-	      << DuckPGQSQL::Column("rowid", next_vertex_element->variable_binding) << ") AS path, "
-	      << DuckPGQSQL::Column("rowid", previous_vertex_element->variable_binding) << " AS src_rowid, "
-	      << DuckPGQSQL::Column("rowid", next_vertex_element->variable_binding) << " AS dst_rowid FROM "
+	      << "), " << DuckPGQSQL::Column(string("rowid"), previous_vertex_element->variable_binding) << ", "
+	      << DuckPGQSQL::Column(string("rowid"), next_vertex_element->variable_binding) << ") AS path, "
+	      << DuckPGQSQL::Column(string("rowid"), previous_vertex_element->variable_binding) << " AS src_rowid, "
+	      << DuckPGQSQL::Column(string("rowid"), next_vertex_element->variable_binding) << " AS dst_rowid FROM "
 	      << DuckPGQSQL::TableRef(*edge_table->source_pg_table, previous_vertex_element->variable_binding)
 	      << " CROSS JOIN "
 	      << DuckPGQSQL::TableRef(*edge_table->destination_pg_table, next_vertex_element->variable_binding)
@@ -571,15 +589,14 @@ unique_ptr<ParsedExpression> PGQMatchFunction::CreatePathFindingFunction(
 				if (next_vertex_subpath) {
 					path_finding_conditions.push_back(std::move(next_vertex_subpath->where_clause));
 				}
-				if (final_select_node->cte_map.map.find(PGQIdentifier("cte1")) ==
-				    final_select_node->cte_map.map.end()) {
+				if (final_select_node->cte_map.map.find(Identifier("cte1")) == final_select_node->cte_map.map.end()) {
 					edge_element = reinterpret_cast<PathElement *>(edge_subpath->path_list[0].get());
 					if (edge_element->match_type == PGQMatchType::MATCH_EDGE_RIGHT) {
-						final_select_node->cte_map.map[PGQIdentifier("cte1")] = CreateDirectedCSRCTE(
+						final_select_node->cte_map.map[Identifier("cte1")] = CreateDirectedCSRCTE(
 						    FindGraphTable(edge_element->label, pg_table), previous_vertex_element->variable_binding,
 						    edge_element->variable_binding, next_vertex_element->variable_binding);
 					} else if (edge_element->match_type == PGQMatchType::MATCH_EDGE_ANY) {
-						final_select_node->cte_map.map[PGQIdentifier("cte1")] =
+						final_select_node->cte_map.map[Identifier("cte1")] =
 						    CreateUndirectedCSRCTE(FindGraphTable(edge_element->label, pg_table), final_select_node);
 					} else {
 						throw NotImplementedException("Cannot do shortest path for edge type %s",
@@ -597,13 +614,13 @@ unique_ptr<ParsedExpression> PGQMatchFunction::CreatePathFindingFunction(
 					                   DuckPGQSQL::ParseFromTableRef(shortest_path_cte_name));
 
 					conditions.push_back(make_uniq<ComparisonExpression>(
-					    ExpressionType::COMPARE_EQUAL, PGQColumnRef("src_rowid", shortest_path_cte_name),
-					    PGQColumnRef("rowid", previous_vertex_element->variable_binding)));
+					    ExpressionType::COMPARE_EQUAL, PGQColumnRef(string("src_rowid"), shortest_path_cte_name),
+					    PGQColumnRef(string("rowid"), previous_vertex_element->variable_binding)));
 					conditions.push_back(make_uniq<ComparisonExpression>(
-					    ExpressionType::COMPARE_EQUAL, PGQColumnRef("dst_rowid", shortest_path_cte_name),
-					    PGQColumnRef("rowid", next_vertex_element->variable_binding)));
+					    ExpressionType::COMPARE_EQUAL, PGQColumnRef(string("dst_rowid"), shortest_path_cte_name),
+					    PGQColumnRef(string("rowid"), next_vertex_element->variable_binding)));
 				}
-				auto shortest_path_ref = PGQColumnRef("path", shortest_path_cte_name);
+				auto shortest_path_ref = PGQColumnRef(string("path"), shortest_path_cte_name);
 				if (!final_list) {
 					final_list = std::move(shortest_path_ref);
 				} else {
@@ -629,9 +646,9 @@ unique_ptr<ParsedExpression> PGQMatchFunction::CreatePathFindingFunction(
 			}
 			edge_element = GetPathElement(edge_subpath->path_list[0]);
 		}
-		auto previous_rowid = PGQColumnRef("rowid", previous_vertex_element->variable_binding);
-		auto edge_rowid = PGQColumnRef("rowid", edge_element->variable_binding);
-		auto next_rowid = PGQColumnRef("rowid", next_vertex_element->variable_binding);
+		auto previous_rowid = PGQColumnRef(string("rowid"), previous_vertex_element->variable_binding);
+		auto edge_rowid = PGQColumnRef(string("rowid"), edge_element->variable_binding);
+		auto next_rowid = PGQColumnRef(string("rowid"), next_vertex_element->variable_binding);
 		auto starting_list_children = vector<unique_ptr<ParsedExpression>>();
 
 		if (!final_list) {
@@ -692,10 +709,10 @@ unique_ptr<ParsedExpression>
 PGQMatchFunction::AddPathQuantifierCondition(const string &prev_binding, const string &next_binding,
                                              const shared_ptr<PropertyGraphTable> &edge_table, const SubPath *subpath) {
 	std::ostringstream expression;
-	expression << "add(" << DuckPGQSQL::Column("temp", "__x") << ", iterativelength(0, ("
+	expression << "add(" << DuckPGQSQL::Column(string("temp"), string("__x")) << ", iterativelength(0, ("
 	           << DuckPGQSQLCountTable(*edge_table->source_pg_table, prev_binding, edge_table->source_pk[0]) << "), "
-	           << DuckPGQSQL::Column("rowid", prev_binding) << ", " << DuckPGQSQL::Column("rowid", next_binding)
-	           << "))";
+	           << DuckPGQSQL::Column(string("rowid"), prev_binding) << ", "
+	           << DuckPGQSQL::Column(string("rowid"), next_binding) << "))";
 	if (subpath->upper == NumericLimits<int64_t>::Maximum()) {
 		expression << " >= " << subpath->lower;
 		return DuckPGQSQL::ParseExpression(expression.str());
@@ -1075,7 +1092,7 @@ unique_ptr<TableRef> PGQMatchFunction::MatchBindReplace(ClientContext &context, 
 				if (named_subpaths.count(column_names[0].GetIdentifierName()) && column_names.size() == 1) {
 					auto path_name = column_names[0].GetIdentifierName();
 					final_column_list.emplace_back(DuckPGQSQL::ParseExpression(
-					    "len(" + DuckPGQSQL::Column("path", path_name) + ") // 2", "path_length_" + path_name,
+					    "len(" + DuckPGQSQL::Column(string("path"), path_name) + ") // 2", "path_length_" + path_name,
 					    "DuckPGQ MATCH path_length projection"));
 				}
 			} else {

--- a/src/core/functions/table/match.cpp
+++ b/src/core/functions/table/match.cpp
@@ -262,6 +262,40 @@ GetColRefExprFromPg(const case_insensitive_map_t<shared_ptr<PropertyGraphTable>>
 	return registered_col_names;
 }
 
+bool IsSameGraphVertexReference(const PropertyGraphTable &edge_table) {
+	if (edge_table.source_pg_table || edge_table.destination_pg_table) {
+		return edge_table.source_pg_table && edge_table.destination_pg_table &&
+		       edge_table.source_pg_table->SameTableIdentity(*edge_table.destination_pg_table);
+	}
+	return Identifier(edge_table.source_catalog) == Identifier(edge_table.destination_catalog) &&
+	       Identifier(edge_table.source_schema) == Identifier(edge_table.destination_schema) &&
+	       Identifier(edge_table.source_reference) == Identifier(edge_table.destination_reference);
+}
+
+string CreateReverseSelfLoopFilter(const PropertyGraphTable &edge_table, const string &edge_binding) {
+	if (!IsSameGraphVertexReference(edge_table)) {
+		return "";
+	}
+
+	vector<string> equality_conditions;
+	for (idx_t source_idx = 0; source_idx < edge_table.source_pk.size(); source_idx++) {
+		for (idx_t destination_idx = 0; destination_idx < edge_table.destination_pk.size(); destination_idx++) {
+			if (Identifier(edge_table.source_pk[source_idx]) != Identifier(edge_table.destination_pk[destination_idx])) {
+				continue;
+			}
+			equality_conditions.push_back(DuckPGQSQL::Column(edge_table.source_fk[source_idx], edge_binding) +
+			                              " IS NOT DISTINCT FROM " +
+			                              DuckPGQSQL::Column(edge_table.destination_fk[destination_idx], edge_binding));
+			break;
+		}
+	}
+
+	if (equality_conditions.size() != edge_table.source_pk.size()) {
+		return "";
+	}
+	return " WHERE NOT (" + StringUtil::Join(equality_conditions, " AND ") + ")";
+}
+
 } // namespace
 
 shared_ptr<PropertyGraphTable> PGQMatchFunction::FindGraphTable(const string &label,
@@ -376,7 +410,7 @@ void PGQMatchFunction::EdgeTypeAny(const shared_ptr<PropertyGraphTable> &edge_ta
 	      << DuckPGQSQL::Identifier(edge_table->source_fk[0]) << ", "
 	      << DuckPGQSQL::Column(edge_table->source_fk[0], edge_binding) << " AS "
 	      << DuckPGQSQL::Identifier(edge_table->destination_fk[0]) << ", * FROM "
-	      << DuckPGQSQL::TableRef(*edge_table, edge_binding);
+	      << DuckPGQSQL::TableRef(*edge_table, edge_binding) << CreateReverseSelfLoopFilter(*edge_table, edge_binding);
 	PGQAppendCrossJoin(from_clause, DuckPGQSQL::ParseSubqueryRef(query.str(), edge_binding));
 	// (a) src.key = edge.src
 	auto src_left_expr =

--- a/src/core/functions/table/summarize_property_graph.cpp
+++ b/src/core/functions/table/summarize_property_graph.cpp
@@ -51,7 +51,7 @@ static string PGQSQLDegreeStatisticExpression(const string &aggregate_function, 
 	return PGQSQLDegreeStatisticExpression(aggregate_function, aggregate_function, is_in_degree, argument);
 }
 
-static string PGQSQLDegreeStatisticsCTE(const shared_ptr<PropertyGraphTable> &pg_table, const string &degree_column,
+static string PGQSQLDegreeStatisticsCTE(const shared_ptr<PropertyGraphTable> &pg_table, const Identifier &degree_column,
                                         bool is_in_degree) {
 	std::ostringstream query;
 	query << "SELECT " << PGQSQLDegreeStatisticExpression("avg", is_in_degree) << ", "
@@ -62,7 +62,7 @@ static string PGQSQLDegreeStatisticsCTE(const shared_ptr<PropertyGraphTable> &pg
 	      << PGQSQLDegreeStatisticExpression("approx_quantile", "q75", is_in_degree, "0.75") << " FROM (SELECT "
 	      << DuckPGQSQL::Identifier(degree_column) << ", count(*) AS "
 	      << DuckPGQSQL::Identifier(PGQSQLDegreeColumn(is_in_degree)) << " FROM "
-	      << DuckPGQSQL::TableRef(*pg_table, "degree_source") << " GROUP BY " << DuckPGQSQL::Identifier(degree_column)
+	      << DuckPGQSQL::TableRef(*pg_table, string("degree_source")) << " GROUP BY " << DuckPGQSQL::Identifier(degree_column)
 	      << ") AS degree_groups";
 	return query.str();
 }
@@ -70,8 +70,8 @@ static string PGQSQLDegreeStatisticsCTE(const shared_ptr<PropertyGraphTable> &pg
 static string PGQSQLDistinctCount(const shared_ptr<PropertyGraphTable> &pg_table, bool is_source) {
 	auto column_to_count = is_source ? pg_table->source_fk[0] : pg_table->destination_fk[0];
 	std::ostringstream query;
-	query << "(SELECT count(DISTINCT " << DuckPGQSQL::Column(column_to_count, "edge_count") << ") FROM "
-	      << DuckPGQSQL::TableRef(*pg_table, "edge_count") << ")";
+	query << "(SELECT count(DISTINCT " << DuckPGQSQL::Column(column_to_count, string("edge_count")) << ") FROM "
+	      << DuckPGQSQL::TableRef(*pg_table, string("edge_count")) << ")";
 	return query.str();
 }
 
@@ -83,23 +83,24 @@ static string PGQSQLIsolatedNodes(shared_ptr<PropertyGraphTable> &pg_table, bool
 	auto fk_reference = is_source ? pg_table->source_fk[0] : pg_table->destination_fk[0];
 
 	std::ostringstream query;
-	query << "(SELECT count(" << DuckPGQSQL::Column(pk_reference, "vertex_table") << ") FROM "
-	      << DuckPGQSQL::TableRef(table_catalog, table_schema, table_reference, "vertex_table") << " LEFT JOIN "
-	      << DuckPGQSQL::TableRef(*pg_table, "edge_table") << " ON " << DuckPGQSQL::Column(pk_reference, "vertex_table")
-	      << " = " << DuckPGQSQL::Column(fk_reference, "edge_table") << " WHERE "
-	      << DuckPGQSQL::Column(fk_reference, "edge_table") << " IS NULL)";
+	query << "(SELECT count(" << DuckPGQSQL::Column(pk_reference, string("vertex_table")) << ") FROM "
+	      << DuckPGQSQL::TableRef(table_catalog, table_schema, table_reference, string("vertex_table")) << " LEFT JOIN "
+	      << DuckPGQSQL::TableRef(*pg_table, string("edge_table")) << " ON "
+	      << DuckPGQSQL::Column(pk_reference, string("vertex_table"))
+	      << " = " << DuckPGQSQL::Column(fk_reference, string("edge_table")) << " WHERE "
+	      << DuckPGQSQL::Column(fk_reference, string("edge_table")) << " IS NULL)";
 	return query.str();
 }
 
 static string PGQSQLDegreeStatisticScalar(const string &aggregate_function, bool is_in_degree) {
 	auto statistic_column = PGQSQLDegreeStatisticColumn(aggregate_function, is_in_degree);
-	auto cte_name = is_in_degree ? "in_degrees" : "out_degrees";
+	string cte_name = is_in_degree ? "in_degrees" : "out_degrees";
 	return "(SELECT " + DuckPGQSQL::Identifier(statistic_column) + " FROM " + DuckPGQSQL::Identifier(cte_name) + ")";
 }
 
 static string PGQSQLVertexTableCTE(const shared_ptr<PropertyGraphTable> &vertex_table) {
 	std::ostringstream query;
-	query << "SELECT " << PGQSQLStringAlias(vertex_table->table_name, "table_name") << ", "
+	query << "SELECT " << PGQSQLStringAlias(vertex_table->table_name.GetIdentifierName(), "table_name") << ", "
 	      << PGQSQLBooleanAlias(true, "is_vertex_table") << ", " << PGQSQLNullAlias("source_table") << ", "
 	      << PGQSQLNullAlias("destination_table") << ", " << PGQSQLCountStarAlias("vertex_count") << ", "
 	      << PGQSQLNullAlias("edge_count") << ", " << PGQSQLNullAlias("unique_source_count") << ", "
@@ -110,7 +111,8 @@ static string PGQSQLVertexTableCTE(const shared_ptr<PropertyGraphTable> &vertex_
 	      << PGQSQLNullAlias("q75_in_degree") << ", " << PGQSQLNullAlias("avg_out_degree") << ", "
 	      << PGQSQLNullAlias("min_out_degree") << ", " << PGQSQLNullAlias("max_out_degree") << ", "
 	      << PGQSQLNullAlias("q25_out_degree") << ", " << PGQSQLNullAlias("q50_out_degree") << ", "
-	      << PGQSQLNullAlias("q75_out_degree") << " FROM " << DuckPGQSQL::TableRef(*vertex_table, "vertex_table");
+	      << PGQSQLNullAlias("q75_out_degree") << " FROM "
+	      << DuckPGQSQL::TableRef(*vertex_table, string("vertex_table"));
 	return query.str();
 }
 
@@ -118,28 +120,44 @@ static string PGQSQLEdgeTableCTE(shared_ptr<PropertyGraphTable> &edge_table) {
 	std::ostringstream query;
 	query << "WITH in_degrees AS (" << PGQSQLDegreeStatisticsCTE(edge_table, edge_table->destination_fk[0], true)
 	      << "), out_degrees AS (" << PGQSQLDegreeStatisticsCTE(edge_table, edge_table->source_fk[0], false)
-	      << ") SELECT " << PGQSQLStringAlias(edge_table->table_name, "table_name") << ", "
+	      << ") SELECT " << PGQSQLStringAlias(edge_table->table_name.GetIdentifierName(), "table_name") << ", "
 	      << PGQSQLBooleanAlias(false, "is_vertex_table") << ", "
-	      << PGQSQLStringAlias(edge_table->source_reference, "source_table") << ", "
-	      << PGQSQLStringAlias(edge_table->destination_reference, "destination_table") << ", "
+	      << PGQSQLStringAlias(edge_table->source_reference.GetIdentifierName(), "source_table") << ", "
+	      << PGQSQLStringAlias(edge_table->destination_reference.GetIdentifierName(), "destination_table") << ", "
 	      << PGQSQLNullAlias("vertex_count") << ", " << PGQSQLCountStarAlias("edge_count") << ", "
-	      << PGQSQLDistinctCount(edge_table, true) << " AS " << DuckPGQSQL::Identifier("unique_source_count") << ", "
-	      << PGQSQLDistinctCount(edge_table, false) << " AS " << DuckPGQSQL::Identifier("unique_destination_count")
-	      << ", " << PGQSQLIsolatedNodes(edge_table, true) << " AS " << DuckPGQSQL::Identifier("isolated_sources")
-	      << ", " << PGQSQLIsolatedNodes(edge_table, false) << " AS " << DuckPGQSQL::Identifier("isolated_destinations")
-	      << ", " << PGQSQLDegreeStatisticScalar("avg", true) << " AS " << DuckPGQSQL::Identifier("avg_in_degree")
-	      << ", " << PGQSQLDegreeStatisticScalar("min", true) << " AS " << DuckPGQSQL::Identifier("min_in_degree")
-	      << ", " << PGQSQLDegreeStatisticScalar("max", true) << " AS " << DuckPGQSQL::Identifier("max_in_degree")
-	      << ", " << PGQSQLDegreeStatisticScalar("q25", true) << " AS " << DuckPGQSQL::Identifier("q25_in_degree")
-	      << ", " << PGQSQLDegreeStatisticScalar("q50", true) << " AS " << DuckPGQSQL::Identifier("q50_in_degree")
-	      << ", " << PGQSQLDegreeStatisticScalar("q75", true) << " AS " << DuckPGQSQL::Identifier("q75_in_degree")
-	      << ", " << PGQSQLDegreeStatisticScalar("avg", false) << " AS " << DuckPGQSQL::Identifier("avg_out_degree")
-	      << ", " << PGQSQLDegreeStatisticScalar("min", false) << " AS " << DuckPGQSQL::Identifier("min_out_degree")
-	      << ", " << PGQSQLDegreeStatisticScalar("max", false) << " AS " << DuckPGQSQL::Identifier("max_out_degree")
-	      << ", " << PGQSQLDegreeStatisticScalar("q25", false) << " AS " << DuckPGQSQL::Identifier("q25_out_degree")
-	      << ", " << PGQSQLDegreeStatisticScalar("q50", false) << " AS " << DuckPGQSQL::Identifier("q50_out_degree")
-	      << ", " << PGQSQLDegreeStatisticScalar("q75", false) << " AS " << DuckPGQSQL::Identifier("q75_out_degree")
-	      << " FROM " << DuckPGQSQL::TableRef(*edge_table, "edge_table");
+	      << PGQSQLDistinctCount(edge_table, true) << " AS "
+	      << DuckPGQSQL::Identifier(string("unique_source_count")) << ", "
+	      << PGQSQLDistinctCount(edge_table, false) << " AS "
+	      << DuckPGQSQL::Identifier(string("unique_destination_count"))
+	      << ", " << PGQSQLIsolatedNodes(edge_table, true) << " AS "
+	      << DuckPGQSQL::Identifier(string("isolated_sources"))
+	      << ", " << PGQSQLIsolatedNodes(edge_table, false) << " AS "
+	      << DuckPGQSQL::Identifier(string("isolated_destinations"))
+	      << ", " << PGQSQLDegreeStatisticScalar("avg", true) << " AS "
+	      << DuckPGQSQL::Identifier(string("avg_in_degree"))
+	      << ", " << PGQSQLDegreeStatisticScalar("min", true) << " AS "
+	      << DuckPGQSQL::Identifier(string("min_in_degree"))
+	      << ", " << PGQSQLDegreeStatisticScalar("max", true) << " AS "
+	      << DuckPGQSQL::Identifier(string("max_in_degree"))
+	      << ", " << PGQSQLDegreeStatisticScalar("q25", true) << " AS "
+	      << DuckPGQSQL::Identifier(string("q25_in_degree"))
+	      << ", " << PGQSQLDegreeStatisticScalar("q50", true) << " AS "
+	      << DuckPGQSQL::Identifier(string("q50_in_degree"))
+	      << ", " << PGQSQLDegreeStatisticScalar("q75", true) << " AS "
+	      << DuckPGQSQL::Identifier(string("q75_in_degree"))
+	      << ", " << PGQSQLDegreeStatisticScalar("avg", false) << " AS "
+	      << DuckPGQSQL::Identifier(string("avg_out_degree"))
+	      << ", " << PGQSQLDegreeStatisticScalar("min", false) << " AS "
+	      << DuckPGQSQL::Identifier(string("min_out_degree"))
+	      << ", " << PGQSQLDegreeStatisticScalar("max", false) << " AS "
+	      << DuckPGQSQL::Identifier(string("max_out_degree"))
+	      << ", " << PGQSQLDegreeStatisticScalar("q25", false) << " AS "
+	      << DuckPGQSQL::Identifier(string("q25_out_degree"))
+	      << ", " << PGQSQLDegreeStatisticScalar("q50", false) << " AS "
+	      << DuckPGQSQL::Identifier(string("q50_out_degree"))
+	      << ", " << PGQSQLDegreeStatisticScalar("q75", false) << " AS "
+	      << DuckPGQSQL::Identifier(string("q75_out_degree"))
+	      << " FROM " << DuckPGQSQL::TableRef(*edge_table, string("edge_table"));
 	return query.str();
 }
 
@@ -220,14 +238,15 @@ SummarizePropertyGraphFunction::CreateGroupBySubquery(const shared_ptr<PropertyG
 	std::ostringstream query;
 	query << "SELECT " << DuckPGQSQL::Identifier(degree_column) << ", count(*) AS "
 	      << DuckPGQSQL::Identifier(PGQSQLDegreeColumn(is_in_degree)) << " FROM "
-	      << DuckPGQSQL::TableRef(*pg_table, "degree_source") << " GROUP BY " << DuckPGQSQL::Identifier(degree_column);
+	      << DuckPGQSQL::TableRef(*pg_table, string("degree_source")) << " GROUP BY "
+	      << DuckPGQSQL::Identifier(degree_column);
 	return DuckPGQSQL::ParseSubqueryRef(query.str());
 }
 
 unique_ptr<CommonTableExpressionInfo>
 SummarizePropertyGraphFunction::CreateDegreeStatisticsCTE(const shared_ptr<PropertyGraphTable> &pg_table,
                                                           const string &degree_column, bool is_in_degree) {
-	return DuckPGQSQL::ParseCTE(PGQSQLDegreeStatisticsCTE(pg_table, degree_column, is_in_degree));
+	return DuckPGQSQL::ParseCTE(PGQSQLDegreeStatisticsCTE(pg_table, Identifier(degree_column), is_in_degree));
 }
 
 unique_ptr<ParsedExpression> SummarizePropertyGraphFunction::GetDegreeStatistics(const string &aggregate_function,

--- a/src/core/functions/table/summarize_property_graph.cpp
+++ b/src/core/functions/table/summarize_property_graph.cpp
@@ -62,8 +62,8 @@ static string PGQSQLDegreeStatisticsCTE(const shared_ptr<PropertyGraphTable> &pg
 	      << PGQSQLDegreeStatisticExpression("approx_quantile", "q75", is_in_degree, "0.75") << " FROM (SELECT "
 	      << DuckPGQSQL::Identifier(degree_column) << ", count(*) AS "
 	      << DuckPGQSQL::Identifier(PGQSQLDegreeColumn(is_in_degree)) << " FROM "
-	      << DuckPGQSQL::TableRef(*pg_table, string("degree_source")) << " GROUP BY " << DuckPGQSQL::Identifier(degree_column)
-	      << ") AS degree_groups";
+	      << DuckPGQSQL::TableRef(*pg_table, string("degree_source")) << " GROUP BY "
+	      << DuckPGQSQL::Identifier(degree_column) << ") AS degree_groups";
 	return query.str();
 }
 
@@ -86,8 +86,8 @@ static string PGQSQLIsolatedNodes(shared_ptr<PropertyGraphTable> &pg_table, bool
 	query << "(SELECT count(" << DuckPGQSQL::Column(pk_reference, string("vertex_table")) << ") FROM "
 	      << DuckPGQSQL::TableRef(table_catalog, table_schema, table_reference, string("vertex_table")) << " LEFT JOIN "
 	      << DuckPGQSQL::TableRef(*pg_table, string("edge_table")) << " ON "
-	      << DuckPGQSQL::Column(pk_reference, string("vertex_table"))
-	      << " = " << DuckPGQSQL::Column(fk_reference, string("edge_table")) << " WHERE "
+	      << DuckPGQSQL::Column(pk_reference, string("vertex_table")) << " = "
+	      << DuckPGQSQL::Column(fk_reference, string("edge_table")) << " WHERE "
 	      << DuckPGQSQL::Column(fk_reference, string("edge_table")) << " IS NULL)";
 	return query.str();
 }
@@ -125,38 +125,27 @@ static string PGQSQLEdgeTableCTE(shared_ptr<PropertyGraphTable> &edge_table) {
 	      << PGQSQLStringAlias(edge_table->source_reference.GetIdentifierName(), "source_table") << ", "
 	      << PGQSQLStringAlias(edge_table->destination_reference.GetIdentifierName(), "destination_table") << ", "
 	      << PGQSQLNullAlias("vertex_count") << ", " << PGQSQLCountStarAlias("edge_count") << ", "
-	      << PGQSQLDistinctCount(edge_table, true) << " AS "
-	      << DuckPGQSQL::Identifier(string("unique_source_count")) << ", "
-	      << PGQSQLDistinctCount(edge_table, false) << " AS "
-	      << DuckPGQSQL::Identifier(string("unique_destination_count"))
-	      << ", " << PGQSQLIsolatedNodes(edge_table, true) << " AS "
-	      << DuckPGQSQL::Identifier(string("isolated_sources"))
-	      << ", " << PGQSQLIsolatedNodes(edge_table, false) << " AS "
-	      << DuckPGQSQL::Identifier(string("isolated_destinations"))
+	      << PGQSQLDistinctCount(edge_table, true) << " AS " << DuckPGQSQL::Identifier(string("unique_source_count"))
+	      << ", " << PGQSQLDistinctCount(edge_table, false) << " AS "
+	      << DuckPGQSQL::Identifier(string("unique_destination_count")) << ", " << PGQSQLIsolatedNodes(edge_table, true)
+	      << " AS " << DuckPGQSQL::Identifier(string("isolated_sources")) << ", "
+	      << PGQSQLIsolatedNodes(edge_table, false) << " AS " << DuckPGQSQL::Identifier(string("isolated_destinations"))
 	      << ", " << PGQSQLDegreeStatisticScalar("avg", true) << " AS "
-	      << DuckPGQSQL::Identifier(string("avg_in_degree"))
-	      << ", " << PGQSQLDegreeStatisticScalar("min", true) << " AS "
-	      << DuckPGQSQL::Identifier(string("min_in_degree"))
-	      << ", " << PGQSQLDegreeStatisticScalar("max", true) << " AS "
-	      << DuckPGQSQL::Identifier(string("max_in_degree"))
+	      << DuckPGQSQL::Identifier(string("avg_in_degree")) << ", " << PGQSQLDegreeStatisticScalar("min", true)
+	      << " AS " << DuckPGQSQL::Identifier(string("min_in_degree")) << ", "
+	      << PGQSQLDegreeStatisticScalar("max", true) << " AS " << DuckPGQSQL::Identifier(string("max_in_degree"))
 	      << ", " << PGQSQLDegreeStatisticScalar("q25", true) << " AS "
-	      << DuckPGQSQL::Identifier(string("q25_in_degree"))
-	      << ", " << PGQSQLDegreeStatisticScalar("q50", true) << " AS "
-	      << DuckPGQSQL::Identifier(string("q50_in_degree"))
-	      << ", " << PGQSQLDegreeStatisticScalar("q75", true) << " AS "
-	      << DuckPGQSQL::Identifier(string("q75_in_degree"))
+	      << DuckPGQSQL::Identifier(string("q25_in_degree")) << ", " << PGQSQLDegreeStatisticScalar("q50", true)
+	      << " AS " << DuckPGQSQL::Identifier(string("q50_in_degree")) << ", "
+	      << PGQSQLDegreeStatisticScalar("q75", true) << " AS " << DuckPGQSQL::Identifier(string("q75_in_degree"))
 	      << ", " << PGQSQLDegreeStatisticScalar("avg", false) << " AS "
-	      << DuckPGQSQL::Identifier(string("avg_out_degree"))
-	      << ", " << PGQSQLDegreeStatisticScalar("min", false) << " AS "
-	      << DuckPGQSQL::Identifier(string("min_out_degree"))
-	      << ", " << PGQSQLDegreeStatisticScalar("max", false) << " AS "
-	      << DuckPGQSQL::Identifier(string("max_out_degree"))
+	      << DuckPGQSQL::Identifier(string("avg_out_degree")) << ", " << PGQSQLDegreeStatisticScalar("min", false)
+	      << " AS " << DuckPGQSQL::Identifier(string("min_out_degree")) << ", "
+	      << PGQSQLDegreeStatisticScalar("max", false) << " AS " << DuckPGQSQL::Identifier(string("max_out_degree"))
 	      << ", " << PGQSQLDegreeStatisticScalar("q25", false) << " AS "
-	      << DuckPGQSQL::Identifier(string("q25_out_degree"))
-	      << ", " << PGQSQLDegreeStatisticScalar("q50", false) << " AS "
-	      << DuckPGQSQL::Identifier(string("q50_out_degree"))
-	      << ", " << PGQSQLDegreeStatisticScalar("q75", false) << " AS "
-	      << DuckPGQSQL::Identifier(string("q75_out_degree"))
+	      << DuckPGQSQL::Identifier(string("q25_out_degree")) << ", " << PGQSQLDegreeStatisticScalar("q50", false)
+	      << " AS " << DuckPGQSQL::Identifier(string("q50_out_degree")) << ", "
+	      << PGQSQLDegreeStatisticScalar("q75", false) << " AS " << DuckPGQSQL::Identifier(string("q75_out_degree"))
 	      << " FROM " << DuckPGQSQL::TableRef(*edge_table, string("edge_table"));
 	return query.str();
 }

--- a/src/core/utils/compressed_sparse_row.cpp
+++ b/src/core/utils/compressed_sparse_row.cpp
@@ -103,7 +103,8 @@ unique_ptr<FunctionData> CSRFunctionData::CSRBind(BindScalarFunctionInput &input
 	return make_uniq<CSRFunctionData>(context, id.GetValue<int32_t>(), LogicalType::BOOLEAN);
 }
 
-static string CSRCountTableSQL(const PropertyGraphTable &table, const string &table_alias, const Identifier &primary_key) {
+static string CSRCountTableSQL(const PropertyGraphTable &table, const string &table_alias,
+                               const Identifier &primary_key) {
 	std::ostringstream query;
 	query << "SELECT count(" << DuckPGQSQL::Column(primary_key, table_alias) << ") FROM "
 	      << DuckPGQSQL::TableRef(table, table_alias);
@@ -216,8 +217,7 @@ unique_ptr<CommonTableExpressionInfo> CreateUndirectedCSRCTE(const shared_ptr<Pr
 	      << CSRCountTableSQL(*edge_table->source_pg_table, edge_table->source_reference.GetIdentifierName(),
 	                          edge_table->source_pk[0])
 	      << "), CAST((" << CSRUndirectedCSRVertexSQL(*edge_table, edge_table->source_reference.GetIdentifierName())
-	      << ") AS BIGINT), ("
-	      << CSRCountUndirectedEdgeTableSQL() << "), src, dst, edge) AS temp FROM ("
+	      << ") AS BIGINT), (" << CSRCountUndirectedEdgeTableSQL() << "), src, dst, edge) AS temp FROM ("
 	      << "SELECT src, dst, any_value(edges) AS edge FROM ("
 	      << "SELECT src, dst, edges FROM edges_cte UNION ALL SELECT dst, src, edges FROM edges_cte"
 	      << ") GROUP BY src, dst)";
@@ -242,8 +242,8 @@ unique_ptr<CommonTableExpressionInfo> CreateDirectedCSRCTE(const shared_ptr<Prop
 	      << CSRDirectedCSRVertexSQL(*edge_table, prev_binding) << ") AS BIGINT), ("
 	      << CSRCountEdgeTableSQL(*edge_table) << "), " << DuckPGQSQL::Column(string("rowid"), prev_binding) << ", "
 	      << DuckPGQSQL::Column(string("rowid"), next_binding) << ", "
-	      << DuckPGQSQL::Column(string("rowid"), edge_binding)
-	      << ") AS temp FROM " << DuckPGQSQL::TableRef(*edge_table, edge_binding) << " INNER JOIN "
+	      << DuckPGQSQL::Column(string("rowid"), edge_binding) << ") AS temp FROM "
+	      << DuckPGQSQL::TableRef(*edge_table, edge_binding) << " INNER JOIN "
 	      << DuckPGQSQL::TableRef(*edge_table->source_pg_table, prev_binding) << " ON "
 	      << DuckPGQSQL::Column(edge_table->source_fk[0], edge_binding) << " = "
 	      << DuckPGQSQL::Column(edge_table->source_pk[0], prev_binding) << " INNER JOIN "

--- a/src/core/utils/compressed_sparse_row.cpp
+++ b/src/core/utils/compressed_sparse_row.cpp
@@ -103,7 +103,7 @@ unique_ptr<FunctionData> CSRFunctionData::CSRBind(BindScalarFunctionInput &input
 	return make_uniq<CSRFunctionData>(context, id.GetValue<int32_t>(), LogicalType::BOOLEAN);
 }
 
-static string CSRCountTableSQL(const PropertyGraphTable &table, const string &table_alias, const string &primary_key) {
+static string CSRCountTableSQL(const PropertyGraphTable &table, const string &table_alias, const Identifier &primary_key) {
 	std::ostringstream query;
 	query << "SELECT count(" << DuckPGQSQL::Column(primary_key, table_alias) << ") FROM "
 	      << DuckPGQSQL::TableRef(table, table_alias);
@@ -113,12 +113,12 @@ static string CSRCountTableSQL(const PropertyGraphTable &table, const string &ta
 static string CSRCountEdgeTableSQL(const PropertyGraphTable &edge_table) {
 	std::ostringstream query;
 	query << "SELECT count() FROM " << DuckPGQSQL::TableRef(edge_table) << " INNER JOIN "
-	      << DuckPGQSQL::TableRef(*edge_table.source_pg_table, "src") << " ON "
+	      << DuckPGQSQL::TableRef(*edge_table.source_pg_table, string("src")) << " ON "
 	      << DuckPGQSQL::Column(edge_table.source_fk[0], edge_table.table_name) << " = "
-	      << DuckPGQSQL::Column(edge_table.source_pk[0], "src") << " INNER JOIN "
-	      << DuckPGQSQL::TableRef(*edge_table.destination_pg_table, "dst") << " ON "
+	      << DuckPGQSQL::Column(edge_table.source_pk[0], string("src")) << " INNER JOIN "
+	      << DuckPGQSQL::TableRef(*edge_table.destination_pg_table, string("dst")) << " ON "
 	      << DuckPGQSQL::Column(edge_table.destination_fk[0], edge_table.table_name) << " = "
-	      << DuckPGQSQL::Column(edge_table.destination_pk[0], "dst");
+	      << DuckPGQSQL::Column(edge_table.destination_pk[0], string("dst"));
 	return query.str();
 }
 
@@ -133,7 +133,7 @@ static string CSRDirectedCSRVertexSQL(const PropertyGraphTable &edge_table, cons
 	std::ostringstream query;
 	query << "SELECT sum(create_csr_vertex(0, ("
 	      << CSRCountTableSQL(*edge_table.source_pg_table, prev_binding, edge_table.source_pk[0])
-	      << "), sub.dense_id, sub.cnt)) FROM (SELECT " << DuckPGQSQL::Column("rowid", prev_binding)
+	      << "), sub.dense_id, sub.cnt)) FROM (SELECT " << DuckPGQSQL::Column(string("rowid"), prev_binding)
 	      << " AS dense_id, count(" << DuckPGQSQL::Column(edge_table.source_fk[0], edge_table.table_name)
 	      << ") AS cnt FROM " << DuckPGQSQL::TableRef(*edge_table.source_pg_table, prev_binding) << " LEFT JOIN "
 	      << DuckPGQSQL::TableRef(edge_table) << " ON "
@@ -144,7 +144,7 @@ static string CSRDirectedCSRVertexSQL(const PropertyGraphTable &edge_table, cons
 
 static string CSRUniqueEdgesSQL(const PropertyGraphTable &edge_table, bool reverse) {
 	std::ostringstream query;
-	query << "SELECT " << DuckPGQSQL::Column("rowid", edge_table.source_reference) << " AS dense_id, ";
+	query << "SELECT " << DuckPGQSQL::Column(string("rowid"), edge_table.source_reference) << " AS dense_id, ";
 	if (!reverse) {
 		query << DuckPGQSQL::Column(edge_table.source_fk[0], edge_table.table_name) << " AS outgoing_edges, "
 		      << DuckPGQSQL::Column(edge_table.destination_fk[0], edge_table.table_name) << " AS incoming_edges FROM "
@@ -173,7 +173,7 @@ static string CSRUndirectedCSRVertexSQL(const PropertyGraphTable &edge_table, co
 
 // Function to create a subquery expression for counting table entries
 unique_ptr<SubqueryExpression> GetCountTable(const shared_ptr<PropertyGraphTable> &table, const string &table_alias,
-                                             const string &primary_key) {
+                                             const Identifier &primary_key) {
 	return DuckPGQSQL::ParseScalarSubquery(CSRCountTableSQL(*table, table_alias, primary_key));
 }
 
@@ -191,16 +191,16 @@ unique_ptr<SubqueryExpression> CreateUndirectedCSRVertexSubquery(const shared_pt
 // Function to create the CTE for the edges
 unique_ptr<CommonTableExpressionInfo> MakeEdgesCTE(const shared_ptr<PropertyGraphTable> &edge_table) {
 	std::ostringstream query;
-	query << "SELECT " << DuckPGQSQL::Column("rowid", "src_table") << " AS src, "
-	      << DuckPGQSQL::Column("rowid", "dst_table") << " AS dst, "
-	      << DuckPGQSQL::Column("rowid", edge_table->table_name) << " AS edges FROM "
+	query << "SELECT " << DuckPGQSQL::Column(string("rowid"), string("src_table")) << " AS src, "
+	      << DuckPGQSQL::Column(string("rowid"), string("dst_table")) << " AS dst, "
+	      << DuckPGQSQL::Column(string("rowid"), edge_table->table_name) << " AS edges FROM "
 	      << DuckPGQSQL::TableRef(*edge_table) << " INNER JOIN "
-	      << DuckPGQSQL::TableRef(*edge_table->source_pg_table, "src_table") << " ON "
+	      << DuckPGQSQL::TableRef(*edge_table->source_pg_table, string("src_table")) << " ON "
 	      << DuckPGQSQL::Column(edge_table->source_fk[0], edge_table->table_name) << " = "
-	      << DuckPGQSQL::Column(edge_table->source_pk[0], "src_table") << " INNER JOIN "
-	      << DuckPGQSQL::TableRef(*edge_table->destination_pg_table, "dst_table") << " ON "
+	      << DuckPGQSQL::Column(edge_table->source_pk[0], string("src_table")) << " INNER JOIN "
+	      << DuckPGQSQL::TableRef(*edge_table->destination_pg_table, string("dst_table")) << " ON "
 	      << DuckPGQSQL::Column(edge_table->destination_fk[0], edge_table->table_name) << " = "
-	      << DuckPGQSQL::Column(edge_table->destination_pk[0], "dst_table");
+	      << DuckPGQSQL::Column(edge_table->destination_pk[0], string("dst_table"));
 	return DuckPGQSQL::ParseCTE(query.str());
 }
 
@@ -213,8 +213,10 @@ unique_ptr<CommonTableExpressionInfo> CreateUndirectedCSRCTE(const shared_ptr<Pr
 
 	std::ostringstream query;
 	query << "SELECT create_csr_edge(0, ("
-	      << CSRCountTableSQL(*edge_table->source_pg_table, edge_table->source_reference, edge_table->source_pk[0])
-	      << "), CAST((" << CSRUndirectedCSRVertexSQL(*edge_table, edge_table->source_reference) << ") AS BIGINT), ("
+	      << CSRCountTableSQL(*edge_table->source_pg_table, edge_table->source_reference.GetIdentifierName(),
+	                          edge_table->source_pk[0])
+	      << "), CAST((" << CSRUndirectedCSRVertexSQL(*edge_table, edge_table->source_reference.GetIdentifierName())
+	      << ") AS BIGINT), ("
 	      << CSRCountUndirectedEdgeTableSQL() << "), src, dst, edge) AS temp FROM ("
 	      << "SELECT src, dst, any_value(edges) AS edge FROM ("
 	      << "SELECT src, dst, edges FROM edges_cte UNION ALL SELECT dst, src, edges FROM edges_cte"
@@ -238,8 +240,9 @@ unique_ptr<CommonTableExpressionInfo> CreateDirectedCSRCTE(const shared_ptr<Prop
 	query << "SELECT create_csr_edge(0, ("
 	      << CSRCountTableSQL(*edge_table->source_pg_table, prev_binding, edge_table->source_pk[0]) << "), CAST(("
 	      << CSRDirectedCSRVertexSQL(*edge_table, prev_binding) << ") AS BIGINT), ("
-	      << CSRCountEdgeTableSQL(*edge_table) << "), " << DuckPGQSQL::Column("rowid", prev_binding) << ", "
-	      << DuckPGQSQL::Column("rowid", next_binding) << ", " << DuckPGQSQL::Column("rowid", edge_binding)
+	      << CSRCountEdgeTableSQL(*edge_table) << "), " << DuckPGQSQL::Column(string("rowid"), prev_binding) << ", "
+	      << DuckPGQSQL::Column(string("rowid"), next_binding) << ", "
+	      << DuckPGQSQL::Column(string("rowid"), edge_binding)
 	      << ") AS temp FROM " << DuckPGQSQL::TableRef(*edge_table, edge_binding) << " INNER JOIN "
 	      << DuckPGQSQL::TableRef(*edge_table->source_pg_table, prev_binding) << " ON "
 	      << DuckPGQSQL::Column(edge_table->source_fk[0], edge_binding) << " = "

--- a/src/core/utils/duckpgq_sql.cpp
+++ b/src/core/utils/duckpgq_sql.cpp
@@ -11,6 +11,10 @@ string DuckPGQSQL::Identifier(const string &identifier) {
 	return SQLIdentifier::ToString(identifier);
 }
 
+string DuckPGQSQL::Identifier(const duckdb::Identifier &identifier) {
+	return Identifier(identifier.GetIdentifierName());
+}
+
 string DuckPGQSQL::StringLiteral(const string &value) {
 	return SQLString::ToString(value);
 }
@@ -27,6 +31,11 @@ string DuckPGQSQL::QualifiedTableName(const string &catalog, const string &schem
 	return result;
 }
 
+string DuckPGQSQL::QualifiedTableName(const duckdb::Identifier &catalog, const duckdb::Identifier &schema,
+                                      const duckdb::Identifier &table) {
+	return QualifiedTableName(catalog.GetIdentifierName(), schema.GetIdentifierName(), table.GetIdentifierName());
+}
+
 string DuckPGQSQL::QualifiedTableName(const PropertyGraphTable &table) {
 	return QualifiedTableName(table.catalog_name, table.schema_name, table.table_name);
 }
@@ -39,6 +48,11 @@ string DuckPGQSQL::TableRef(const string &catalog, const string &schema, const s
 	return result;
 }
 
+string DuckPGQSQL::TableRef(const duckdb::Identifier &catalog, const duckdb::Identifier &schema,
+                            const duckdb::Identifier &table, const string &alias) {
+	return TableRef(catalog.GetIdentifierName(), schema.GetIdentifierName(), table.GetIdentifierName(), alias);
+}
+
 string DuckPGQSQL::TableRef(const PropertyGraphTable &table, const string &alias) {
 	auto result = QualifiedTableName(table);
 	if (!alias.empty()) {
@@ -47,11 +61,27 @@ string DuckPGQSQL::TableRef(const PropertyGraphTable &table, const string &alias
 	return result;
 }
 
+string DuckPGQSQL::TableRef(const PropertyGraphTable &table, const duckdb::Identifier &alias) {
+	return TableRef(table, alias.GetIdentifierName());
+}
+
 string DuckPGQSQL::Column(const string &column_name, const string &table_name) {
 	if (table_name.empty()) {
 		return Identifier(column_name);
 	}
 	return Identifier(table_name) + "." + Identifier(column_name);
+}
+
+string DuckPGQSQL::Column(const duckdb::Identifier &column_name, const string &table_name) {
+	return Column(column_name.GetIdentifierName(), table_name);
+}
+
+string DuckPGQSQL::Column(const string &column_name, const duckdb::Identifier &table_name) {
+	return Column(column_name, table_name.GetIdentifierName());
+}
+
+string DuckPGQSQL::Column(const duckdb::Identifier &column_name, const duckdb::Identifier &table_name) {
+	return Column(column_name.GetIdentifierName(), table_name.GetIdentifierName());
 }
 
 unique_ptr<SelectStatement> DuckPGQSQL::ParseSelect(const string &query, const string &context) {

--- a/src/core/utils/duckpgq_utils.cpp
+++ b/src/core/utils/duckpgq_utils.cpp
@@ -64,8 +64,8 @@ unique_ptr<SelectNode> CreateSelectNode(const shared_ptr<PropertyGraphTable> &ed
                                         const string &function_name, const string &function_alias) {
 	std::ostringstream query;
 	query << "SELECT " << DuckPGQSQL::Column(edge_pg_entry->source_pk[0], edge_pg_entry->source_reference) << ", add("
-	      << DuckPGQSQL::Column("temp", "__x") << ", " << DuckPGQSQL::Identifier(function_name) << "(0, "
-	      << DuckPGQSQL::Column("rowid", edge_pg_entry->source_reference) << ")) AS "
+	      << DuckPGQSQL::Column(string("temp"), string("__x")) << ", " << DuckPGQSQL::Identifier(function_name) << "(0, "
+	      << DuckPGQSQL::Column(string("rowid"), edge_pg_entry->source_reference) << ")) AS "
 	      << DuckPGQSQL::Identifier(function_alias) << " FROM "
 	      << DuckPGQSQL::TableRef(*edge_pg_entry->source_pg_table, edge_pg_entry->source_reference)
 	      << " CROSS JOIN (SELECT multiply(0, count(csr_cte.temp)) AS temp FROM csr_cte) AS __x";

--- a/src/core/utils/duckpgq_utils.cpp
+++ b/src/core/utils/duckpgq_utils.cpp
@@ -64,8 +64,8 @@ unique_ptr<SelectNode> CreateSelectNode(const shared_ptr<PropertyGraphTable> &ed
                                         const string &function_name, const string &function_alias) {
 	std::ostringstream query;
 	query << "SELECT " << DuckPGQSQL::Column(edge_pg_entry->source_pk[0], edge_pg_entry->source_reference) << ", add("
-	      << DuckPGQSQL::Column(string("temp"), string("__x")) << ", " << DuckPGQSQL::Identifier(function_name) << "(0, "
-	      << DuckPGQSQL::Column(string("rowid"), edge_pg_entry->source_reference) << ")) AS "
+	      << DuckPGQSQL::Column(string("temp"), string("__x")) << ", " << DuckPGQSQL::Identifier(function_name)
+	      << "(0, " << DuckPGQSQL::Column(string("rowid"), edge_pg_entry->source_reference) << ")) AS "
 	      << DuckPGQSQL::Identifier(function_alias) << " FROM "
 	      << DuckPGQSQL::TableRef(*edge_pg_entry->source_pg_table, edge_pg_entry->source_reference)
 	      << " CROSS JOIN (SELECT multiply(0, count(csr_cte.temp)) AS temp FROM csr_cte) AS __x";

--- a/src/duckpgq_state.cpp
+++ b/src/duckpgq_state.cpp
@@ -57,14 +57,14 @@ void DuckPGQState::ProcessPropertyGraphs(unique_ptr<MaterializedQueryResult> &pr
 		auto table = make_shared_ptr<PropertyGraphTable>();
 
 		// Extract and validate common properties
-		table->table_name = chunk->GetValue(1, i).GetValue<string>();
-		table->main_label = chunk->GetValue(2, i).GetValue<string>();
+		table->table_name = Identifier(chunk->GetValue(1, i).GetValue<string>());
+		table->main_label = Identifier(chunk->GetValue(2, i).GetValue<string>());
 		table->is_vertex_table = chunk->GetValue(3, i).GetValue<bool>();
 
 		// Handle discriminator and sub-labels
 		const auto &discriminator = chunk->GetValue(10, i).GetValue<string>();
 		if (discriminator != "NULL") {
-			table->discriminator = discriminator;
+			table->discriminator = Identifier(discriminator);
 			auto sublabels = ListValue::GetChildren(chunk->GetValue(11, i));
 			for (const auto &sublabel : sublabels) {
 				table->sub_labels.emplace_back(sublabel.GetValue<string>());
@@ -73,32 +73,32 @@ void DuckPGQState::ProcessPropertyGraphs(unique_ptr<MaterializedQueryResult> &pr
 
 		// Extract catalog and schema names
 		if (chunk->ColumnCount() > 12) {
-			table->catalog_name = chunk->GetValue(12, i).GetValue<string>();
-			table->schema_name = chunk->GetValue(13, i).GetValue<string>();
+			table->catalog_name = Identifier(chunk->GetValue(12, i).GetValue<string>());
+			table->schema_name = Identifier(chunk->GetValue(13, i).GetValue<string>());
 		} else {
-			table->catalog_name = "";
-			table->schema_name = DEFAULT_SCHEMA;
+			table->catalog_name = Identifier();
+			table->schema_name = Identifier::DefaultSchema();
 		}
 		if (chunk->ColumnCount() > 14) {
-			table->source_catalog = chunk->GetValue(14, i).GetValue<string>();
-			table->source_schema = chunk->GetValue(15, i).GetValue<string>();
-			table->destination_catalog = chunk->GetValue(16, i).GetValue<string>();
-			table->destination_schema = chunk->GetValue(17, i).GetValue<string>();
+			table->source_catalog = Identifier(chunk->GetValue(14, i).GetValue<string>());
+			table->source_schema = Identifier(chunk->GetValue(15, i).GetValue<string>());
+			table->destination_catalog = Identifier(chunk->GetValue(16, i).GetValue<string>());
+			table->destination_schema = Identifier(chunk->GetValue(17, i).GetValue<string>());
 		} else {
-			table->source_catalog = "";
-			table->schema_name = DEFAULT_SCHEMA;
-			table->destination_catalog = "";
-			table->destination_schema = DEFAULT_SCHEMA;
+			table->source_catalog = Identifier();
+			table->source_schema = Identifier::DefaultSchema();
+			table->destination_catalog = Identifier();
+			table->destination_schema = Identifier::DefaultSchema();
 		}
 		if (chunk->ColumnCount() > 18) {
 			// read properties
 			auto properties = ListValue::GetChildren(chunk->GetValue(18, i));
 			for (const auto &property : properties) {
-				table->column_names.push_back(property.GetValue<string>());
+				table->column_names.emplace_back(property.GetValue<string>());
 			}
 			auto column_aliases = ListValue::GetChildren(chunk->GetValue(19, i));
 			for (const auto &alias : column_aliases) {
-				table->column_aliases.push_back(alias.GetValue<string>());
+				table->column_aliases.emplace_back(alias.GetValue<string>());
 			}
 		} else {
 			table->all_columns = true;
@@ -114,19 +114,19 @@ void DuckPGQState::ProcessPropertyGraphs(unique_ptr<MaterializedQueryResult> &pr
 }
 
 void DuckPGQState::PopulateEdgeSpecificFields(unique_ptr<DataChunk> &chunk, idx_t row_idx, PropertyGraphTable &table) {
-	table.source_reference = chunk->GetValue(4, row_idx).GetValue<string>();
+	table.source_reference = Identifier(chunk->GetValue(4, row_idx).GetValue<string>());
 	ExtractListValues(chunk->GetValue(5, row_idx), table.source_pk);
 	ExtractListValues(chunk->GetValue(6, row_idx), table.source_fk);
-	table.destination_reference = chunk->GetValue(7, row_idx).GetValue<string>();
+	table.destination_reference = Identifier(chunk->GetValue(7, row_idx).GetValue<string>());
 	ExtractListValues(chunk->GetValue(8, row_idx), table.destination_pk);
 	ExtractListValues(chunk->GetValue(9, row_idx), table.destination_fk);
 }
 
-void DuckPGQState::ExtractListValues(const Value &list_value, vector<string> &output) {
+void DuckPGQState::ExtractListValues(const Value &list_value, vector<Identifier> &output) {
 	auto children = ListValue::GetChildren(list_value);
 	output.reserve(output.size() + children.size());
 	for (const auto &child : children) {
-		output.push_back(child.GetValue<string>());
+		output.emplace_back(child.GetValue<string>());
 	}
 }
 
@@ -138,7 +138,7 @@ void DuckPGQState::RegisterPropertyGraph(const shared_ptr<PropertyGraphTable> &t
 	}
 
 	auto &pg_info = registered_property_graphs[graph_name]->Cast<CreatePropertyGraphInfo>();
-	pg_info.label_map[table->main_label] = table;
+	pg_info.label_map[table->main_label.GetIdentifierName()] = table;
 
 	if (!table->discriminator.empty()) {
 		for (const auto &label : table->sub_labels) {
@@ -150,10 +150,12 @@ void DuckPGQState::RegisterPropertyGraph(const shared_ptr<PropertyGraphTable> &t
 		pg_info.vertex_tables.push_back(table);
 	} else {
 		table->source_pg_table =
-		    pg_info.GetTableByName(table->source_catalog, table->source_schema, table->source_reference);
+		    pg_info.GetTableByName(table->source_catalog.GetIdentifierName(), table->source_schema.GetIdentifierName(),
+		                           table->source_reference.GetIdentifierName());
 		D_ASSERT(table->source_pg_table);
-		table->destination_pg_table =
-		    pg_info.GetTableByName(table->destination_catalog, table->destination_schema, table->destination_reference);
+		table->destination_pg_table = pg_info.GetTableByName(table->destination_catalog.GetIdentifierName(),
+		                                                     table->destination_schema.GetIdentifierName(),
+		                                                     table->destination_reference.GetIdentifierName());
 		D_ASSERT(table->destination_pg_table);
 		pg_info.edge_tables.push_back(table);
 	}

--- a/src/include/duckpgq/core/functions/table/create_property_graph.hpp
+++ b/src/include/duckpgq/core/functions/table/create_property_graph.hpp
@@ -50,13 +50,14 @@ public:
 	                                            const case_insensitive_set_t &v_table_names);
 
 	static void ValidatePrimaryKeyInTable(ClientContext &context, shared_ptr<PropertyGraphTable> &pg_table,
-	                                      const vector<string> &pk_columns);
+	                                      const vector<Identifier> &pk_columns);
 
-	static void ValidateKeys(shared_ptr<PropertyGraphTable> &edge_table, const string &reference,
-	                         const string &key_type, vector<string> &pk_columns, vector<string> &fk_columns,
+	static void ValidateKeys(shared_ptr<PropertyGraphTable> &edge_table, const Identifier &reference,
+	                         const string &key_type, vector<Identifier> &pk_columns, vector<Identifier> &fk_columns,
 	                         const vector<unique_ptr<Constraint>> &table_constraints);
 
-	static void ValidateForeignKeyColumns(shared_ptr<PropertyGraphTable> &edge_table, const vector<string> &fk_columns,
+	static void ValidateForeignKeyColumns(shared_ptr<PropertyGraphTable> &edge_table,
+	                                      const vector<Identifier> &fk_columns,
 	                                      optional_ptr<TableCatalogEntry> &table);
 
 	static unique_ptr<GlobalTableFunctionState> CreatePropertyGraphInit(ClientContext &context,

--- a/src/include/duckpgq/core/functions/table/create_property_graph.hpp
+++ b/src/include/duckpgq/core/functions/table/create_property_graph.hpp
@@ -57,8 +57,7 @@ public:
 	                         const vector<unique_ptr<Constraint>> &table_constraints);
 
 	static void ValidateForeignKeyColumns(shared_ptr<PropertyGraphTable> &edge_table,
-	                                      const vector<Identifier> &fk_columns,
-	                                      optional_ptr<TableCatalogEntry> &table);
+	                                      const vector<Identifier> &fk_columns, optional_ptr<TableCatalogEntry> &table);
 
 	static unique_ptr<GlobalTableFunctionState> CreatePropertyGraphInit(ClientContext &context,
 	                                                                    TableFunctionInitInput &input);

--- a/src/include/duckpgq/core/functions/table/match.hpp
+++ b/src/include/duckpgq/core/functions/table/match.hpp
@@ -43,10 +43,11 @@ public:
 	static void CheckInheritance(const shared_ptr<PropertyGraphTable> &tableref, PathElement *element,
 	                             vector<unique_ptr<ParsedExpression>> &conditions);
 
-	static void CheckEdgeTableConstraints(const string &src_reference, const string &dst_reference,
+	static void CheckEdgeTableConstraints(const Identifier &src_reference, const Identifier &dst_reference,
 	                                      const shared_ptr<PropertyGraphTable> &edge_table);
 
-	static unique_ptr<ParsedExpression> CreateMatchJoinExpression(vector<string> vertex_keys, vector<string> edge_keys,
+	static unique_ptr<ParsedExpression> CreateMatchJoinExpression(vector<Identifier> vertex_keys,
+	                                                              vector<Identifier> edge_keys,
 	                                                              const string &vertex_alias, const string &edge_alias);
 
 	// Populate all vertex and edge tables and their alias into
@@ -74,12 +75,12 @@ public:
 	                        const string &prev_binding, const string &next_binding,
 	                        vector<unique_ptr<ParsedExpression>> &conditions, unique_ptr<TableRef> &from_clause);
 
-	static void EdgeTypeLeft(const shared_ptr<PropertyGraphTable> &edge_table, const string &next_table_name,
-	                         const string &prev_table_name, const string &edge_binding, const string &prev_binding,
+	static void EdgeTypeLeft(const shared_ptr<PropertyGraphTable> &edge_table, const Identifier &next_table_name,
+	                         const Identifier &prev_table_name, const string &edge_binding, const string &prev_binding,
 	                         const string &next_binding, vector<unique_ptr<ParsedExpression>> &conditions);
 
-	static void EdgeTypeRight(const shared_ptr<PropertyGraphTable> &edge_table, const string &next_table_name,
-	                          const string &prev_table_name, const string &edge_binding, const string &prev_binding,
+	static void EdgeTypeRight(const shared_ptr<PropertyGraphTable> &edge_table, const Identifier &next_table_name,
+	                          const Identifier &prev_table_name, const string &edge_binding, const string &prev_binding,
 	                          const string &next_binding, vector<unique_ptr<ParsedExpression>> &conditions);
 
 	static void EdgeTypeLeftRight(const shared_ptr<PropertyGraphTable> &edge_table, const string &edge_binding,

--- a/src/include/duckpgq/core/utils/compressed_sparse_row.hpp
+++ b/src/include/duckpgq/core/utils/compressed_sparse_row.hpp
@@ -73,7 +73,7 @@ unique_ptr<SubqueryExpression> CreateDirectedCSRVertexSubquery(const shared_ptr<
 unique_ptr<SubqueryExpression> CreateUndirectedCSRVertexSubquery(const shared_ptr<PropertyGraphTable> &edge_table,
                                                                  const string &binding);
 unique_ptr<SubqueryExpression> GetCountTable(const shared_ptr<PropertyGraphTable> &table, const string &table_alias,
-                                             const string &primary_key);
+                                             const Identifier &primary_key);
 unique_ptr<SubqueryRef> CreateCountCTESubquery();
 unique_ptr<SubqueryExpression> GetCountUndirectedEdgeTable();
 unique_ptr<SubqueryExpression> GetCountEdgeTable(const shared_ptr<PropertyGraphTable> &edge_table);

--- a/src/include/duckpgq/core/utils/duckpgq_sql.hpp
+++ b/src/include/duckpgq/core/utils/duckpgq_sql.hpp
@@ -13,12 +13,21 @@ namespace duckdb {
 
 struct DuckPGQSQL {
 	static string Identifier(const string &identifier);
+	static string Identifier(const duckdb::Identifier &identifier);
 	static string StringLiteral(const string &value);
 	static string QualifiedTableName(const string &catalog, const string &schema, const string &table);
+	static string QualifiedTableName(const duckdb::Identifier &catalog, const duckdb::Identifier &schema,
+	                                 const duckdb::Identifier &table);
 	static string QualifiedTableName(const PropertyGraphTable &table);
 	static string TableRef(const string &catalog, const string &schema, const string &table, const string &alias = "");
+	static string TableRef(const duckdb::Identifier &catalog, const duckdb::Identifier &schema,
+	                       const duckdb::Identifier &table, const string &alias = "");
 	static string TableRef(const PropertyGraphTable &table, const string &alias = "");
+	static string TableRef(const PropertyGraphTable &table, const duckdb::Identifier &alias);
 	static string Column(const string &column_name, const string &table_name = "");
+	static string Column(const duckdb::Identifier &column_name, const string &table_name = "");
+	static string Column(const string &column_name, const duckdb::Identifier &table_name);
+	static string Column(const duckdb::Identifier &column_name, const duckdb::Identifier &table_name);
 
 	static unique_ptr<SelectStatement> ParseSelect(const string &query, const string &context = "DuckPGQ query");
 	static unique_ptr<CommonTableExpressionInfo> ParseCTE(const string &query, const string &context = "DuckPGQ query");

--- a/src/include/duckpgq/parser/parsed_data/create_property_graph_info.hpp
+++ b/src/include/duckpgq/parser/parsed_data/create_property_graph_info.hpp
@@ -170,7 +170,7 @@ public:
 			if (pg_table->is_vertex_table != is_vertex_table) {
 				continue;
 			}
-			if (pg_table->table_name == label) {
+			if (pg_table->table_name.GetIdentifierName() == label) {
 				throw Exception(
 				    ExceptionType::INVALID,
 				    "Table '" + label +

--- a/src/include/duckpgq/parser/parsed_data/create_property_graph_info.hpp
+++ b/src/include/duckpgq/parser/parsed_data/create_property_graph_info.hpp
@@ -179,10 +179,10 @@ public:
 			}
 
 			// Use int64_t for the distance calculations
-			auto distance_main_label = LevenshteinDistance(label, pg_table->main_label);
+			auto distance_main_label = LevenshteinDistance(label, pg_table->main_label.GetIdentifierName());
 			if (distance_main_label < min_distance) {
 				min_distance = distance_main_label;
-				closest_label = pg_table->main_label;
+				closest_label = pg_table->main_label.GetIdentifierName();
 			}
 
 			for (const auto &sub_label : pg_table->sub_labels) {

--- a/src/include/duckpgq/parser/property_graph_table.hpp
+++ b/src/include/duckpgq/parser/property_graph_table.hpp
@@ -23,11 +23,11 @@ public:
 	//! Used for Copy
 	PropertyGraphTable();
 	//! Specify both the column and table name
-	PropertyGraphTable(string table_name, vector<string> column_name, const vector<string> &label,
+	PropertyGraphTable(string table_name, const vector<string> &column_name, const vector<string> &label,
 	                   string catalog_name = "", string schema = DEFAULT_SCHEMA);
 	//! Specify both the column and table name with alias
-	PropertyGraphTable(string table_name, string table_alias, vector<string> column_name, const vector<string> &label,
-	                   string catalog_name = "", string schema = DEFAULT_SCHEMA);
+	PropertyGraphTable(string table_name, string table_alias, const vector<string> &column_name,
+	                   const vector<string> &label, string catalog_name = "", string schema = DEFAULT_SCHEMA);
 	Identifier table_name;
 	Identifier table_name_alias;
 

--- a/src/include/duckpgq/parser/property_graph_table.hpp
+++ b/src/include/duckpgq/parser/property_graph_table.hpp
@@ -76,6 +76,7 @@ public:
 public:
 	string ToString() const;
 	bool Equals(const PropertyGraphTable *other_p) const;
+	bool SameTableIdentity(const PropertyGraphTable &other) const;
 
 	shared_ptr<PropertyGraphTable> Copy() const;
 

--- a/src/include/duckpgq/parser/property_graph_table.hpp
+++ b/src/include/duckpgq/parser/property_graph_table.hpp
@@ -28,20 +28,20 @@ public:
 	//! Specify both the column and table name with alias
 	PropertyGraphTable(string table_name, string table_alias, vector<string> column_name, const vector<string> &label,
 	                   string catalog_name = "", string schema = DEFAULT_SCHEMA);
-	string table_name;
-	string table_name_alias;
+	Identifier table_name;
+	Identifier table_name_alias;
 
 	//! The stack of names in order of which they appear (column_names[0], column_names[1], column_names[2], ...)
-	vector<string> column_names;
-	vector<string> column_aliases;
+	vector<Identifier> column_names;
+	vector<Identifier> column_aliases;
 
-	vector<string> except_columns;
+	vector<Identifier> except_columns;
 
 	vector<Identifier> sub_labels;
-	string main_label;
+	Identifier main_label;
 
-	string catalog_name;
-	string schema_name;
+	Identifier catalog_name;
+	Identifier schema_name;
 
 	//! Associated with the PROPERTIES keyword not mentioned in the creation of table, equalling SELECT * in some sense
 	bool all_columns = false;
@@ -51,25 +51,25 @@ public:
 
 	bool is_vertex_table = false;
 
-	string discriminator;
+	Identifier discriminator;
 
-	vector<string> source_fk;
+	vector<Identifier> source_fk;
 
-	vector<string> source_pk;
+	vector<Identifier> source_pk;
 
-	string source_catalog;
-	string source_schema;
-	string source_reference;
+	Identifier source_catalog;
+	Identifier source_schema;
+	Identifier source_reference;
 
 	shared_ptr<PropertyGraphTable> source_pg_table;
 
-	vector<string> destination_fk;
+	vector<Identifier> destination_fk;
 
-	vector<string> destination_pk;
+	vector<Identifier> destination_pk;
 
-	string destination_catalog;
-	string destination_schema;
-	string destination_reference;
+	Identifier destination_catalog;
+	Identifier destination_schema;
+	Identifier destination_reference;
 
 	shared_ptr<PropertyGraphTable> destination_pg_table;
 
@@ -97,11 +97,11 @@ public:
 
 	unique_ptr<BaseTableRef> CreateBaseTableRef(const string &alias = "") const {
 		auto base_table_ref = make_uniq<BaseTableRef>();
-		base_table_ref->SetQualifiedName(Identifier(catalog_name), Identifier(schema_name), Identifier(table_name));
+		base_table_ref->SetQualifiedName(catalog_name, schema_name, table_name);
 		base_table_ref->alias = Identifier(alias.empty() ? "" : alias);
 		return base_table_ref;
 	}
 
-	bool IsSourceTable(const string &table_name);
+	bool IsSourceTable(const Identifier &table_name);
 };
 } // namespace duckdb

--- a/src/include/duckpgq_state.hpp
+++ b/src/include/duckpgq_state.hpp
@@ -21,7 +21,7 @@ public:
 	void RetrievePropertyGraphs(const shared_ptr<Connection> &context);
 	void ProcessPropertyGraphs(unique_ptr<MaterializedQueryResult> &property_graphs, bool is_vertex);
 	void PopulateEdgeSpecificFields(unique_ptr<DataChunk> &chunk, idx_t row_idx, PropertyGraphTable &table);
-	static void ExtractListValues(const Value &list_value, vector<string> &output);
+	static void ExtractListValues(const Value &list_value, vector<Identifier> &output);
 	void RegisterPropertyGraph(const shared_ptr<PropertyGraphTable> &table, const string &graph_name, bool is_vertex);
 
 public:

--- a/src/parser/parsed_data/create_property_graph_info.cpp
+++ b/src/parser/parsed_data/create_property_graph_info.cpp
@@ -19,7 +19,7 @@ unique_ptr<CreateInfo> CreatePropertyGraphInfo::Copy() const {
 		for (auto &label : copied_vertex_table->sub_labels) {
 			result->label_map[label.GetIdentifierName()] = copied_vertex_table;
 		}
-		result->label_map[copied_vertex_table->main_label] = copied_vertex_table;
+		result->label_map[copied_vertex_table->main_label.GetIdentifierName()] = copied_vertex_table;
 		result->vertex_tables.push_back(std::move(copied_vertex_table));
 	}
 	for (auto &edge_table : edge_tables) {
@@ -27,7 +27,7 @@ unique_ptr<CreateInfo> CreatePropertyGraphInfo::Copy() const {
 		for (auto &label : copied_edge_table->sub_labels) {
 			result->label_map[label.GetIdentifierName()] = copied_edge_table;
 		}
-		result->label_map[copied_edge_table->main_label] = copied_edge_table;
+		result->label_map[copied_edge_table->main_label.GetIdentifierName()] = copied_edge_table;
 		result->edge_tables.push_back(std::move(copied_edge_table));
 	}
 	return std::move(result);

--- a/src/parser/property_graph_table.cpp
+++ b/src/parser/property_graph_table.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 
 PropertyGraphTable::PropertyGraphTable() = default;
 
-PropertyGraphTable::PropertyGraphTable(string table_name_p, vector<string> column_names_p,
+PropertyGraphTable::PropertyGraphTable(string table_name_p, const vector<string> &column_names_p,
                                        const vector<string> &labels_p, string catalog_p, string schema_p)
     : table_name(std::move(table_name_p)), column_names(StringsToIdentifiers(column_names_p)),
       sub_labels(StringsToIdentifiers(labels_p)), catalog_name(std::move(catalog_p)), schema_name(std::move(schema_p)) {
@@ -21,8 +21,9 @@ PropertyGraphTable::PropertyGraphTable(string table_name_p, vector<string> colum
 #endif
 }
 
-PropertyGraphTable::PropertyGraphTable(string table_name_p, string table_name_alias_p, vector<string> column_names_p,
-                                       const vector<string> &labels_p, string catalog_p, string schema_p)
+PropertyGraphTable::PropertyGraphTable(string table_name_p, string table_name_alias_p,
+                                       const vector<string> &column_names_p, const vector<string> &labels_p,
+                                       string catalog_p, string schema_p)
     : table_name(std::move(table_name_p)), table_name_alias(std::move(table_name_alias_p)),
       column_names(StringsToIdentifiers(column_names_p)), sub_labels(StringsToIdentifiers(labels_p)),
       catalog_name(std::move(catalog_p)), schema_name(std::move(schema_p)) {

--- a/src/parser/property_graph_table.cpp
+++ b/src/parser/property_graph_table.cpp
@@ -8,7 +8,7 @@ PropertyGraphTable::PropertyGraphTable() = default;
 
 PropertyGraphTable::PropertyGraphTable(string table_name_p, vector<string> column_names_p,
                                        const vector<string> &labels_p, string catalog_p, string schema_p)
-    : table_name(std::move(table_name_p)), column_names(std::move(column_names_p)),
+    : table_name(std::move(table_name_p)), column_names(StringsToIdentifiers(column_names_p)),
       sub_labels(StringsToIdentifiers(labels_p)), catalog_name(std::move(catalog_p)), schema_name(std::move(schema_p)) {
 #ifdef DEBUG
 	for (auto &col_name : column_names) {
@@ -24,7 +24,7 @@ PropertyGraphTable::PropertyGraphTable(string table_name_p, vector<string> colum
 PropertyGraphTable::PropertyGraphTable(string table_name_p, string table_name_alias_p, vector<string> column_names_p,
                                        const vector<string> &labels_p, string catalog_p, string schema_p)
     : table_name(std::move(table_name_p)), table_name_alias(std::move(table_name_alias_p)),
-      column_names(std::move(column_names_p)), sub_labels(StringsToIdentifiers(labels_p)),
+      column_names(StringsToIdentifiers(column_names_p)), sub_labels(StringsToIdentifiers(labels_p)),
       catalog_name(std::move(catalog_p)), schema_name(std::move(schema_p)) {
 #ifdef DEBUG
 	for (auto &col_name : column_names) {
@@ -237,9 +237,7 @@ bool PropertyGraphTable::Equals(const PropertyGraphTable *other_p) const {
 }
 
 bool PropertyGraphTable::SameTableIdentity(const PropertyGraphTable &other) const {
-	return Identifier(catalog_name) == Identifier(other.catalog_name) &&
-	       Identifier(schema_name) == Identifier(other.schema_name) &&
-	       Identifier(table_name) == Identifier(other.table_name);
+	return catalog_name == other.catalog_name && schema_name == other.schema_name && table_name == other.table_name;
 }
 
 void PropertyGraphTable::Serialize(Serializer &serializer) const {
@@ -313,8 +311,8 @@ shared_ptr<PropertyGraphTable> PropertyGraphTable::Deserialize(Deserializer &des
 	return pg_table;
 }
 
-bool PropertyGraphTable::IsSourceTable(const string &table_name) {
-	return StringUtil::Lower(this->source_reference) == StringUtil::Lower(table_name);
+bool PropertyGraphTable::IsSourceTable(const Identifier &table_name) {
+	return source_reference == table_name;
 }
 
 shared_ptr<PropertyGraphTable> PropertyGraphTable::Copy() const {

--- a/src/parser/property_graph_table.cpp
+++ b/src/parser/property_graph_table.cpp
@@ -236,6 +236,12 @@ bool PropertyGraphTable::Equals(const PropertyGraphTable *other_p) const {
 	return true;
 }
 
+bool PropertyGraphTable::SameTableIdentity(const PropertyGraphTable &other) const {
+	return Identifier(catalog_name) == Identifier(other.catalog_name) &&
+	       Identifier(schema_name) == Identifier(other.schema_name) &&
+	       Identifier(table_name) == Identifier(other.table_name);
+}
+
 void PropertyGraphTable::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty(100, "catalog_name", catalog_name);
 

--- a/test/sql/pattern_matching/undirected_edges.test
+++ b/test/sql/pattern_matching/undirected_edges.test
@@ -66,3 +66,33 @@ Daniel	Peter	12
 Daniel	Peter	13
 Daniel	Tavneet	10
 
+statement ok
+CREATE TABLE Person(id BIGINT NOT NULL);
+
+statement ok
+CREATE TABLE Person_knows_Person(Person1Id BIGINT NOT NULL, Person2Id BIGINT NOT NULL);
+
+statement ok
+INSERT INTO Person VALUES (1);
+
+statement ok
+INSERT INTO Person_knows_Person VALUES (1, 1);
+
+statement ok
+CREATE PROPERTY GRAPH self_loop_pg
+VERTEX TABLES (Person)
+EDGE TABLES (
+    Person_knows_Person SOURCE KEY (Person1Id) REFERENCES Person (id)
+                        DESTINATION KEY (Person2Id) REFERENCES Person (id)
+                        LABEL Knows
+);
+
+query II
+SELECT *
+FROM GRAPH_TABLE (
+    self_loop_pg
+    MATCH (person1:Person)-[k:Knows]-(person1:Person)
+    COLUMNS (k.Person1Id, k.Person2Id)
+);
+----
+1	1

--- a/third_party/duckdb_peg_parser/upstream/src/parser/peg/transformer/transform_pgq.cpp
+++ b/third_party/duckdb_peg_parser/upstream/src/parser/peg/transformer/transform_pgq.cpp
@@ -18,15 +18,6 @@ static string PGQIdentifierName(const Identifier &identifier) {
 	return identifier.GetIdentifierName();
 }
 
-static vector<string> PGQIdentifierNames(const vector<Identifier> &identifiers) {
-	vector<string> result;
-	result.reserve(identifiers.size());
-	for (auto &identifier : identifiers) {
-		result.push_back(PGQIdentifierName(identifier));
-	}
-	return result;
-}
-
 static vector<Identifier> PGQIdentifiers(const vector<Identifier> &identifiers) {
 	vector<Identifier> result;
 	result.reserve(identifiers.size());
@@ -38,14 +29,14 @@ static vector<Identifier> PGQIdentifiers(const vector<Identifier> &identifiers) 
 
 static void PGQApplyBaseTableName(PropertyGraphTable &table, const BaseTableRef &base_table_name) {
 	auto &qualified_name = base_table_name.GetQualifiedName();
-	table.catalog_name = PGQIdentifierName(qualified_name.Catalog());
-	table.schema_name = PGQIdentifierName(qualified_name.Schema());
-	table.table_name = PGQIdentifierName(qualified_name.Name());
+	table.catalog_name = qualified_name.Catalog();
+	table.schema_name = qualified_name.Schema();
+	table.table_name = qualified_name.Name();
 }
 
 static void PGQApplyTableAlias(PropertyGraphTable &table, const optional<TableAlias> &table_alias) {
 	if (table_alias) {
-		table.table_name_alias = PGQIdentifierName(table_alias->name);
+		table.table_name_alias = table_alias->name;
 	}
 }
 
@@ -54,24 +45,24 @@ static void PGQApplyProperties(PropertyGraphTable &table, const optional<Propert
 		table.all_columns = true;
 		return;
 	}
-	table.column_names = PGQIdentifierNames(properties->columns);
-	table.except_columns = PGQIdentifierNames(properties->except_columns);
+	table.column_names = PGQIdentifiers(properties->columns);
+	table.except_columns = PGQIdentifiers(properties->except_columns);
 	table.all_columns = properties->all_columns;
 	table.no_columns = properties->no_columns;
 }
 
 static void PGQApplyLabel(PropertyGraphTable &table, const optional<PropertyGraphLabel> &label) {
 	if (label && !label->main_label.GetIdentifierName().empty()) {
-		table.main_label = PGQIdentifierName(label->main_label);
+		table.main_label = label->main_label;
 		if (label->sub_labels) {
-			table.discriminator = PGQIdentifierName(label->sub_labels->discriminator);
+			table.discriminator = label->sub_labels->discriminator;
 			table.sub_labels = PGQIdentifiers(label->sub_labels->labels);
 		}
 	} else {
 		table.main_label = table.table_name_alias.empty() ? table.table_name : table.table_name_alias;
 	}
 	if (label && label->main_label.GetIdentifierName().empty() && label->sub_labels) {
-		table.discriminator = PGQIdentifierName(label->sub_labels->discriminator);
+		table.discriminator = label->sub_labels->discriminator;
 		table.sub_labels = PGQIdentifiers(label->sub_labels->labels);
 	}
 }
@@ -87,28 +78,28 @@ static void PGQApplyReference(PropertyGraphTable &edge_table, PropertyGraphTable
 	auto &foreign_keys = source ? edge_table.source_fk : edge_table.destination_fk;
 	auto &primary_keys = source ? edge_table.source_pk : edge_table.destination_pk;
 
-	catalog = PGQIdentifierName(qualified_name.Catalog());
-	schema = PGQIdentifierName(qualified_name.Schema());
-	table = PGQIdentifierName(qualified_name.Name());
-	foreign_keys = PGQIdentifierNames(reference.foreign_keys);
-	primary_keys = PGQIdentifierNames(reference.primary_keys);
+	catalog = qualified_name.Catalog();
+	schema = qualified_name.Schema();
+	table = qualified_name.Name();
+	foreign_keys = PGQIdentifiers(reference.foreign_keys);
+	primary_keys = PGQIdentifiers(reference.primary_keys);
 }
 
-static bool PGQMatchesVertexReference(const shared_ptr<PropertyGraphTable> &vertex_table, const string &catalog_name,
-                                      const string &schema_name, const string &table_name) {
-	if (!catalog_name.empty() && !StringUtil::CIEquals(vertex_table->catalog_name, catalog_name)) {
+static bool PGQMatchesVertexReference(const shared_ptr<PropertyGraphTable> &vertex_table, const Identifier &catalog_name,
+                                      const Identifier &schema_name, const Identifier &table_name) {
+	if (!catalog_name.empty() && vertex_table->catalog_name != catalog_name) {
 		return false;
 	}
-	if (!schema_name.empty() && !StringUtil::CIEquals(vertex_table->schema_name, schema_name)) {
+	if (!schema_name.empty() && vertex_table->schema_name != schema_name) {
 		return false;
 	}
-	return StringUtil::CIEquals(vertex_table->table_name, table_name) ||
-	       (!vertex_table->table_name_alias.empty() && StringUtil::CIEquals(vertex_table->table_name_alias, table_name));
+	return vertex_table->table_name == table_name ||
+	       (!vertex_table->table_name_alias.empty() && vertex_table->table_name_alias == table_name);
 }
 
 static shared_ptr<PropertyGraphTable> PGQFindVertexTable(const vector<shared_ptr<PropertyGraphTable>> &vertex_tables,
-                                                         const string &catalog_name, const string &schema_name,
-                                                         const string &table_name) {
+                                                         const Identifier &catalog_name, const Identifier &schema_name,
+                                                         const Identifier &table_name) {
 	for (auto &vertex_table : vertex_tables) {
 		if (PGQMatchesVertexReference(vertex_table, catalog_name, schema_name, table_name)) {
 			return vertex_table;
@@ -127,11 +118,14 @@ static void PGQLinkEdgeReferences(CreatePropertyGraphInfo &info) {
 	}
 }
 
-static void PGQRegisterLabel(CreatePropertyGraphInfo &info, const string &label, const shared_ptr<PropertyGraphTable> &table) {
-	if (info.label_map.find(label) != info.label_map.end()) {
-		throw ConstraintException("Label %s is not unique, make sure all labels are unique", StringUtil::Lower(label));
+static void PGQRegisterLabel(CreatePropertyGraphInfo &info, const Identifier &label,
+                             const shared_ptr<PropertyGraphTable> &table) {
+	auto label_name = label.GetIdentifierName();
+	if (info.label_map.find(label_name) != info.label_map.end()) {
+		throw ConstraintException("Label %s is not unique, make sure all labels are unique",
+		                          StringUtil::Lower(label_name));
 	}
-	info.label_map[label] = table;
+	info.label_map[label_name] = table;
 }
 
 unique_ptr<CreateStatement> PEGTransformerFactory::TransformCreatePropertyGraphStmt(
@@ -152,13 +146,13 @@ unique_ptr<CreateStatement> PEGTransformerFactory::TransformCreatePropertyGraphS
 	for (auto &vertex_table : info->vertex_tables) {
 		PGQRegisterLabel(*info, vertex_table->main_label, vertex_table);
 		for (auto &label : vertex_table->sub_labels) {
-			PGQRegisterLabel(*info, label.GetIdentifierName(), vertex_table);
+			PGQRegisterLabel(*info, label, vertex_table);
 		}
 	}
 	for (auto &edge_table : info->edge_tables) {
 		PGQRegisterLabel(*info, edge_table->main_label, edge_table);
 		for (auto &label : edge_table->sub_labels) {
-			PGQRegisterLabel(*info, label.GetIdentifierName(), edge_table);
+			PGQRegisterLabel(*info, label, edge_table);
 		}
 	}
 	result->info = std::move(info);


### PR DESCRIPTION
Fix: https://github.com/cwida/duckpgq-extension/issues/314

Fixes duplicate rows for undirected self-loop edge patterns and refactors property graph metadata to use `Identifier` instead of raw strings for identifier-like fields