### PR TITLE
fix: CSR sizing under deleted rows, and cross-connection registry/CSR races

### DIFF
--- a/src/core/functions/scalar/csr_creation.cpp
+++ b/src/core/functions/scalar/csr_creation.cpp
@@ -44,34 +44,41 @@ static void CsrInitializeEdge(DuckPGQState &context, int32_t id, int64_t v_size,
 	const lock_guard<mutex> csr_init_lock(context.csr_lock);
 
 	auto csr_entry = context.csr_list.find(id);
-	if (csr_entry->second->initialized_e) {
+	if (csr_entry == context.csr_list.end()) {
+		throw ConstraintException("CSR not found with ID %d", id);
+	}
+	auto &csr = csr_entry->second;
+	if (csr->initialized_e) {
 		return;
 	}
 	try {
-		csr_entry->second->e.resize(e_size, 0);
-		csr_entry->second->edge_ids.resize(e_size, 0);
+		csr->e.resize(e_size, 0);
+		csr->edge_ids.resize(e_size, 0);
 	} catch (std::bad_alloc const &) {
 		throw Exception(ExceptionType::INTERNAL, "Unable to initialize vector of size for csr edge table "
 		                                         "representation");
 	}
 	for (auto i = 1; i < v_size + 2; i++) {
-		csr_entry->second->v[i] += csr_entry->second->v[i - 1];
+		csr->v[i] += csr->v[i - 1];
 	}
-	csr_entry->second->initialized_e = true;
+	csr->initialized_e = true;
 }
 
 static void CsrInitializeWeight(DuckPGQState &context, int32_t id, int64_t e_size, PhysicalType weight_type) {
 	const lock_guard<mutex> csr_init_lock(context.csr_lock);
 	auto csr_entry = context.csr_list.find(id);
-
-	if (csr_entry->second->initialized_w) {
+	if (csr_entry == context.csr_list.end()) {
+		throw ConstraintException("CSR not found with ID %d", id);
+	}
+	auto &csr = csr_entry->second;
+	if (csr->initialized_w) {
 		return;
 	}
 	try {
 		if (weight_type == PhysicalType::INT64) {
-			csr_entry->second->w.resize(e_size, 0);
+			csr->w.resize(e_size, 0);
 		} else if (weight_type == PhysicalType::DOUBLE) {
-			csr_entry->second->w_double.resize(e_size, 0);
+			csr->w_double.resize(e_size, 0);
 		} else {
 			throw NotImplementedException("Unrecognized weight type detected.");
 		}
@@ -80,7 +87,7 @@ static void CsrInitializeWeight(DuckPGQState &context, int32_t id, int64_t e_siz
 		                                         "representation");
 	}
 
-	csr_entry->second->initialized_w = true;
+	csr->initialized_w = true;
 }
 
 static void CreateCsrVertexFunction(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -89,21 +96,13 @@ static void CreateCsrVertexFunction(DataChunk &args, ExpressionState &state, Vec
 
 	auto duckpgq_state = GetDuckPGQState(info.context);
 	int64_t input_size = args.data[1].GetValue(0).GetValue<int64_t>();
-	auto csr_entry = duckpgq_state->csr_list.find(info.id);
-
-	if (csr_entry == duckpgq_state->csr_list.end()) {
-		CsrInitializeVertex(*duckpgq_state, info.id, input_size);
-		csr_entry = duckpgq_state->csr_list.find(info.id);
-	} else {
-		if (!csr_entry->second->initialized_v) {
-			CsrInitializeVertex(*duckpgq_state, info.id, input_size);
-		}
-	}
+	CsrInitializeVertex(*duckpgq_state, info.id, input_size);
+	auto csr = duckpgq_state->GetCSR(info.id);
 
 	BinaryExecutor::Execute<int64_t, int64_t, int64_t>(args.data[2], args.data[3], result, args.size(),
 	                                                   [&](int64_t src, int64_t cnt) {
 		                                                   int64_t edge_count = 0;
-		                                                   csr_entry->second->v[src + 2] = cnt;
+		                                                   csr->v[src + 2] = cnt;
 		                                                   edge_count = edge_count + cnt;
 		                                                   return edge_count;
 	                                                   });
@@ -124,24 +123,20 @@ static void CreateCsrEdgeFunction(DataChunk &args, ExpressionState &state, Vecto
 		                          "vertices referred by edge tables exist and are unique for path-finding queries.");
 	}
 
-	auto csr_entry = duckpgq_state->csr_list.find(info.id);
-	if (!csr_entry->second->initialized_e) {
-		CsrInitializeEdge(*duckpgq_state, info.id, vertex_size, edge_size);
-	}
+	CsrInitializeEdge(*duckpgq_state, info.id, vertex_size, edge_size);
+	auto csr = duckpgq_state->GetCSR(info.id);
 	if (info.weight_type == LogicalType::SQLNULL) {
 		TernaryExecutor::Execute<int64_t, int64_t, int64_t, int32_t>(
 		    args.data[4], args.data[5], args.data[6], result, [&](int64_t src, int64_t dst, int64_t edge_id) {
-			    auto pos = ++csr_entry->second->v[src + 1];
-			    csr_entry->second->e[(int64_t)pos - 1] = dst;
-			    csr_entry->second->edge_ids[(int64_t)pos - 1] = edge_id;
+			    auto pos = ++csr->v[src + 1];
+			    csr->e[(int64_t)pos - 1] = dst;
+			    csr->edge_ids[(int64_t)pos - 1] = edge_id;
 			    return 1;
 		    });
 		return;
 	}
 	auto weight_type = args.data[7].GetType().InternalType();
-	if (!csr_entry->second->initialized_w) {
-		CsrInitializeWeight(*duckpgq_state, info.id, edge_size, weight_type);
-	}
+	CsrInitializeWeight(*duckpgq_state, info.id, edge_size, weight_type);
 	UnifiedVectorFormat src_data, dst_data, edge_id_data, weight_data;
 	args.data[4].ToUnifiedFormat(src_data);
 	args.data[5].ToUnifiedFormat(dst_data);
@@ -166,11 +161,11 @@ static void CreateCsrEdgeFunction(DataChunk &args, ExpressionState &state, Vecto
 				continue;
 			}
 			auto src = src_values[src_idx];
-			auto pos = ++csr_entry->second->v[src + 1];
+			auto pos = ++csr->v[src + 1];
 			auto weight = weight_values[weight_idx];
-			csr_entry->second->e[(int64_t)pos - 1] = dst_values[dst_idx];
-			csr_entry->second->edge_ids[(int64_t)pos - 1] = edge_id_values[edge_id_idx];
-			csr_entry->second->w[(int64_t)pos - 1] = weight;
+			csr->e[(int64_t)pos - 1] = dst_values[dst_idx];
+			csr->edge_ids[(int64_t)pos - 1] = edge_id_values[edge_id_idx];
+			csr->w[(int64_t)pos - 1] = weight;
 			result_data[i] = static_cast<int32_t>(weight);
 		}
 		return;
@@ -188,11 +183,11 @@ static void CreateCsrEdgeFunction(DataChunk &args, ExpressionState &state, Vecto
 			continue;
 		}
 		auto src = src_values[src_idx];
-		auto pos = ++csr_entry->second->v[src + 1];
+		auto pos = ++csr->v[src + 1];
 		auto weight = weight_values[weight_idx];
-		csr_entry->second->e[(int64_t)pos - 1] = dst_values[dst_idx];
-		csr_entry->second->edge_ids[(int64_t)pos - 1] = edge_id_values[edge_id_idx];
-		csr_entry->second->w_double[(int64_t)pos - 1] = weight;
+		csr->e[(int64_t)pos - 1] = dst_values[dst_idx];
+		csr->edge_ids[(int64_t)pos - 1] = edge_id_values[edge_id_idx];
+		csr->w_double[(int64_t)pos - 1] = weight;
 		result_data[i] = static_cast<int32_t>(weight);
 	}
 }

--- a/src/core/functions/scalar/csr_deletion.cpp
+++ b/src/core/functions/scalar/csr_deletion.cpp
@@ -13,7 +13,11 @@ static void DeleteCsrFunction(DataChunk &args, ExpressionState &state, Vector &r
 
 	auto duckpgq_state = GetDuckPGQState(info.context);
 
-	auto flag = duckpgq_state->csr_list.erase(info.id);
+	size_t flag;
+	{
+		lock_guard<mutex> guard(duckpgq_state->csr_lock);
+		flag = duckpgq_state->csr_list.erase(info.id);
+	}
 	result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	auto result_data = ConstantVector::GetData<bool>(result);
 	result_data[0] = flag == 1;

--- a/src/core/functions/scalar/iterativelength2.cpp
+++ b/src/core/functions/scalar/iterativelength2.cpp
@@ -36,10 +36,10 @@ static void IterativeLength2Function(DataChunk &args, ExpressionState &state, Ve
 
 	auto duckpgq_state = GetDuckPGQState(info.context);
 
-	D_ASSERT(duckpgq_state->csr_list[info.csr_id]);
+	auto csr = duckpgq_state->GetCSR(info.csr_id);
 	int64_t v_size = args.data[1].GetValue(0).GetValue<int64_t>();
-	int64_t *v = reinterpret_cast<int64_t *>(duckpgq_state->csr_list[info.csr_id]->v);
-	vector<int64_t> &e = duckpgq_state->csr_list[info.csr_id]->e;
+	int64_t *v = reinterpret_cast<int64_t *>(csr->v);
+	vector<int64_t> &e = csr->e;
 
 	// get src and dst vectors for searches
 	auto &src = args.data[2];

--- a/src/core/functions/scalar/iterativelength_bidirectional.cpp
+++ b/src/core/functions/scalar/iterativelength_bidirectional.cpp
@@ -46,10 +46,10 @@ static void IterativeLengthBidirectionalFunction(DataChunk &args, ExpressionStat
 
 	auto duckpgq_state = GetDuckPGQState(info.context);
 
-	D_ASSERT(duckpgq_state->csr_list[info.csr_id]);
+	auto csr = duckpgq_state->GetCSR(info.csr_id);
 	int64_t v_size = args.data[1].GetValue(0).GetValue<int64_t>();
-	int64_t *v = reinterpret_cast<int64_t *>(duckpgq_state->csr_list[info.csr_id]->v);
-	vector<int64_t> &e = duckpgq_state->csr_list[info.csr_id]->e;
+	int64_t *v = reinterpret_cast<int64_t *>(csr->v);
+	vector<int64_t> &e = csr->e;
 
 	// get src and dst vectors for searches
 	auto &src = args.data[2];

--- a/src/core/functions/scalar/shortest_path.cpp
+++ b/src/core/functions/scalar/shortest_path.cpp
@@ -45,12 +45,7 @@ static void ShortestPathFunction(DataChunk &args, ExpressionState &state, Vector
 	auto &info = func_expr.BindInfo()->Cast<IterativeLengthFunctionData>();
 	auto duckpgq_state = GetDuckPGQState(info.context);
 
-	D_ASSERT(duckpgq_state->csr_list[info.csr_id]);
-	auto csr_entry = duckpgq_state->csr_list.find(info.csr_id);
-	if (csr_entry == duckpgq_state->csr_list.end()) {
-		throw ConstraintException("Invalid ID");
-	}
-	auto &csr = csr_entry->second;
+	auto csr = duckpgq_state->GetCSR(info.csr_id);
 
 	if (!csr->initialized_v) {
 		throw ConstraintException("Need to initialize CSR before doing shortest path");

--- a/src/core/functions/table/create_property_graph.cpp
+++ b/src/core/functions/table/create_property_graph.cpp
@@ -217,12 +217,14 @@ unique_ptr<FunctionData> CreatePropertyGraphFunction::CreatePropertyGraphBind(Cl
 	}
 	auto statement = dynamic_cast<CreateStatement *>(duckpgq_parse_data->statement.get());
 	auto info = dynamic_cast<CreatePropertyGraphInfo *>(statement->info.get());
-	auto pg_table = duckpgq_state->registered_property_graphs.find(info->property_graph_name);
-
-	if (pg_table != duckpgq_state->registered_property_graphs.end() &&
-	    info->on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
-		throw Exception(ExceptionType::INVALID,
-		                "Property graph table with name " + info->property_graph_name + " already exists");
+	{
+		lock_guard<mutex> guard(duckpgq_state->property_graph_lock);
+		auto pg_table = duckpgq_state->registered_property_graphs.find(info->property_graph_name);
+		if (pg_table != duckpgq_state->registered_property_graphs.end() &&
+		    info->on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
+			throw Exception(ExceptionType::INVALID,
+			                "Property graph table with name " + info->property_graph_name + " already exists");
+		}
 	}
 
 	case_insensitive_set_t v_table_names;
@@ -328,7 +330,11 @@ void CreatePropertyGraphFunction::CreatePropertyGraphFunc(ClientContext &context
 	auto duckpgq_state = GetDuckPGQState(context);
 
 	for (auto &local_client_context : ConnectionManager::Get(*context.db).GetConnectionList()) {
-		auto local_state = GetDuckPGQState(*local_client_context);
+		auto local_state = local_client_context->registered_state->Get<DuckPGQState>("duckpgq");
+		if (!local_state) {
+			continue;
+		}
+		lock_guard<mutex> guard(local_state->property_graph_lock);
 		local_state->registered_property_graphs[pg_info->property_graph_name] = pg_info->Copy();
 	}
 

--- a/src/core/functions/table/create_property_graph.cpp
+++ b/src/core/functions/table/create_property_graph.cpp
@@ -335,7 +335,8 @@ void CreatePropertyGraphFunction::CreatePropertyGraphFunc(ClientContext &context
 			continue;
 		}
 		lock_guard<mutex> guard(local_state->property_graph_lock);
-		local_state->registered_property_graphs[pg_info->property_graph_name] = pg_info->Copy();
+		local_state->registered_property_graphs[pg_info->property_graph_name] =
+		    shared_ptr<CreateInfo>(pg_info->Copy().release());
 	}
 
 	duckpgq_state->InitializeInternalTable(context);

--- a/src/core/functions/table/describe_property_graph.cpp
+++ b/src/core/functions/table/describe_property_graph.cpp
@@ -31,7 +31,7 @@ unique_ptr<FunctionData> DescribePropertyGraphFunction::DescribePropertyGraphBin
 	if (pg_table == duckpgq_state->registered_property_graphs.end()) {
 		throw Exception(ExceptionType::INVALID, "Property graph " + property_graph_name + " does not exist.");
 	}
-	auto property_graph = dynamic_cast<CreatePropertyGraphInfo *>(pg_table->second.get());
+	auto property_graph = shared_ptr_cast<CreateInfo, CreatePropertyGraphInfo>(pg_table->second);
 	names.emplace_back("property_graph");
 	return_types.emplace_back(LogicalType::VARCHAR);
 	names.emplace_back("table_name");

--- a/src/core/functions/table/describe_property_graph.cpp
+++ b/src/core/functions/table/describe_property_graph.cpp
@@ -26,6 +26,7 @@ unique_ptr<FunctionData> DescribePropertyGraphFunction::DescribePropertyGraphBin
 	auto show_ref = dynamic_cast<ShowRef *>(select_node->from_table.get());
 
 	auto property_graph_name = show_ref->GetTableName().GetIdentifierName();
+	lock_guard<mutex> guard(duckpgq_state->property_graph_lock);
 	auto pg_table = duckpgq_state->registered_property_graphs.find(property_graph_name);
 	if (pg_table == duckpgq_state->registered_property_graphs.end()) {
 		throw Exception(ExceptionType::INVALID, "Property graph " + property_graph_name + " does not exist.");

--- a/src/core/functions/table/drop_property_graph.cpp
+++ b/src/core/functions/table/drop_property_graph.cpp
@@ -37,12 +37,15 @@ void DropPropertyGraphFunction::DropPropertyGraphFunc(ClientContext &context, Ta
 	auto pg_info = bind_data.drop_pg_info;
 	auto duckpgq_state = GetDuckPGQState(context);
 
-	auto registered_pg = duckpgq_state->registered_property_graphs.find(pg_info->property_graph_name);
-	if (registered_pg == duckpgq_state->registered_property_graphs.end()) {
-		if (pg_info->missing_ok) {
-			return; // Do nothing
+	{
+		lock_guard<mutex> guard(duckpgq_state->property_graph_lock);
+		auto registered_pg = duckpgq_state->registered_property_graphs.find(pg_info->property_graph_name);
+		if (registered_pg == duckpgq_state->registered_property_graphs.end()) {
+			if (pg_info->missing_ok) {
+				return; // Do nothing
+			}
+			throw BinderException("Property graph %s does not exist.", pg_info->property_graph_name);
 		}
-		throw BinderException("Property graph %s does not exist.", pg_info->property_graph_name);
 	}
 
 	for (auto &connection : ConnectionManager::Get(*context.db).GetConnectionList()) {
@@ -50,6 +53,7 @@ void DropPropertyGraphFunction::DropPropertyGraphFunc(ClientContext &context, Ta
 		if (!local_state) {
 			continue;
 		}
+		lock_guard<mutex> guard(local_state->property_graph_lock);
 		local_state->registered_property_graphs.erase(pg_info->property_graph_name);
 	}
 

--- a/src/core/functions/table/local_clustering_coefficient.cpp
+++ b/src/core/functions/table/local_clustering_coefficient.cpp
@@ -23,7 +23,7 @@ LocalClusteringCoefficientFunction::LocalClusteringCoefficientBindReplace(Client
 
 	auto duckpgq_state = GetDuckPGQState(context);
 	auto pg_info = GetPropertyGraphInfo(duckpgq_state, pg_name);
-	auto edge_pg_entry = ValidateSourceNodeAndEdgeTable(pg_info, node_label, edge_label);
+	auto edge_pg_entry = ValidateSourceNodeAndEdgeTable(pg_info.get(), node_label, edge_label);
 
 	auto select_node = CreateSelectNode(edge_pg_entry, "local_clustering_coefficient", "local_clustering_coefficient");
 

--- a/src/core/functions/table/match.cpp
+++ b/src/core/functions/table/match.cpp
@@ -1022,7 +1022,7 @@ unique_ptr<TableRef> PGQMatchFunction::MatchBindReplace(ClientContext &context, 
 
 	auto match_index = bind_input.inputs[0].GetValue<int32_t>();
 	auto *ref = dynamic_cast<MatchExpression *>(duckpgq_state->transform_expression[match_index].get());
-	auto *pg_table = duckpgq_state->GetPropertyGraph(ref->pg_name);
+	auto pg_table = duckpgq_state->GetPropertyGraph(ref->pg_name);
 
 	vector<unique_ptr<ParsedExpression>> conditions;
 

--- a/src/core/functions/table/match.cpp
+++ b/src/core/functions/table/match.cpp
@@ -72,7 +72,7 @@ static unique_ptr<ColumnRefExpression> PGQColumnRef(const string &table_name, co
 static string DuckPGQSQLCountTable(const PropertyGraphTable &table, const string &table_alias,
                                    const Identifier &primary_key) {
 	std::ostringstream query;
-	query << "SELECT count(" << DuckPGQSQL::Column(primary_key, table_alias) << ") FROM "
+	query << "SELECT coalesce(max(" << DuckPGQSQL::Column(string("rowid"), table_alias) << ") + 1, 0) FROM "
 	      << DuckPGQSQL::TableRef(table, table_alias);
 	return query.str();
 }

--- a/src/core/functions/table/pagerank.cpp
+++ b/src/core/functions/table/pagerank.cpp
@@ -14,7 +14,7 @@ unique_ptr<TableRef> PageRankFunction::PageRankBindReplace(ClientContext &contex
 
 	auto duckpgq_state = GetDuckPGQState(context);
 	auto pg_info = GetPropertyGraphInfo(duckpgq_state, pg_name);
-	auto edge_pg_entry = ValidateSourceNodeAndEdgeTable(pg_info, node_table, edge_table);
+	auto edge_pg_entry = ValidateSourceNodeAndEdgeTable(pg_info.get(), node_table, edge_table);
 
 	auto select_node = CreateSelectNode(edge_pg_entry, "pagerank", "pagerank");
 

--- a/src/core/functions/table/weakly_connected_component.cpp
+++ b/src/core/functions/table/weakly_connected_component.cpp
@@ -16,7 +16,7 @@ WeaklyConnectedComponentFunction::WeaklyConnectedComponentBindReplace(ClientCont
 
 	auto duckpgq_state = GetDuckPGQState(context);
 	auto pg_info = GetPropertyGraphInfo(duckpgq_state, pg_name);
-	auto edge_pg_entry = ValidateSourceNodeAndEdgeTable(pg_info, node_table, edge_table);
+	auto edge_pg_entry = ValidateSourceNodeAndEdgeTable(pg_info.get(), node_table, edge_table);
 
 	auto select_node = CreateSelectNode(edge_pg_entry, "weakly_connected_component", "componentId");
 

--- a/src/core/utils/compressed_sparse_row.cpp
+++ b/src/core/utils/compressed_sparse_row.cpp
@@ -106,7 +106,7 @@ unique_ptr<FunctionData> CSRFunctionData::CSRBind(BindScalarFunctionInput &input
 static string CSRCountTableSQL(const PropertyGraphTable &table, const string &table_alias,
                                const Identifier &primary_key) {
 	std::ostringstream query;
-	query << "SELECT count(" << DuckPGQSQL::Column(primary_key, table_alias) << ") FROM "
+	query << "SELECT coalesce(max(" << DuckPGQSQL::Column(string("rowid"), table_alias) << ") + 1, 0) FROM "
 	      << DuckPGQSQL::TableRef(table, table_alias);
 	return query.str();
 }

--- a/src/core/utils/duckpgq_utils.cpp
+++ b/src/core/utils/duckpgq_utils.cpp
@@ -33,6 +33,7 @@ shared_ptr<DuckPGQState> GetDuckPGQState(ClientContext &context, bool throw_not_
 
 // Function to get PropertyGraphInfo from DuckPGQState
 CreatePropertyGraphInfo *GetPropertyGraphInfo(const shared_ptr<DuckPGQState> &duckpgq_state, const string &pg_name) {
+	lock_guard<mutex> guard(duckpgq_state->property_graph_lock);
 	auto property_graph = duckpgq_state->registered_property_graphs.find(pg_name);
 	if (property_graph == duckpgq_state->registered_property_graphs.end()) {
 		throw Exception(ExceptionType::INVALID, "Property graph " + pg_name + " not found");

--- a/src/core/utils/duckpgq_utils.cpp
+++ b/src/core/utils/duckpgq_utils.cpp
@@ -32,13 +32,14 @@ shared_ptr<DuckPGQState> GetDuckPGQState(ClientContext &context, bool throw_not_
 }
 
 // Function to get PropertyGraphInfo from DuckPGQState
-CreatePropertyGraphInfo *GetPropertyGraphInfo(const shared_ptr<DuckPGQState> &duckpgq_state, const string &pg_name) {
+shared_ptr<CreatePropertyGraphInfo> GetPropertyGraphInfo(const shared_ptr<DuckPGQState> &duckpgq_state,
+                                                         const string &pg_name) {
 	lock_guard<mutex> guard(duckpgq_state->property_graph_lock);
 	auto property_graph = duckpgq_state->registered_property_graphs.find(pg_name);
 	if (property_graph == duckpgq_state->registered_property_graphs.end()) {
 		throw Exception(ExceptionType::INVALID, "Property graph " + pg_name + " not found");
 	}
-	return dynamic_cast<CreatePropertyGraphInfo *>(property_graph->second.get());
+	return shared_ptr_cast<CreateInfo, CreatePropertyGraphInfo>(property_graph->second);
 }
 
 // Function to validate the source node and edge table

--- a/src/duckpgq_state.cpp
+++ b/src/duckpgq_state.cpp
@@ -132,6 +132,7 @@ void DuckPGQState::ExtractListValues(const Value &list_value, vector<Identifier>
 
 void DuckPGQState::RegisterPropertyGraph(const shared_ptr<PropertyGraphTable> &table, const string &graph_name,
                                          bool is_vertex) {
+	lock_guard<mutex> guard(property_graph_lock);
 	// Ensure the property graph exists in the registry
 	if (registered_property_graphs.find(graph_name) == registered_property_graphs.end()) {
 		registered_property_graphs[graph_name] = make_uniq<CreatePropertyGraphInfo>(graph_name);
@@ -165,13 +166,17 @@ void DuckPGQState::QueryEnd() {
 	parse_data.reset();
 	transform_expression.clear();
 	match_index = 0; // Reset the index
-	for (const auto &csr_id : csr_to_delete) {
-		csr_list.erase(csr_id);
+	{
+		lock_guard<mutex> guard(csr_lock);
+		for (const auto &csr_id : csr_to_delete) {
+			csr_list.erase(csr_id);
+		}
 	}
 	csr_to_delete.clear();
 }
 
 CreatePropertyGraphInfo *DuckPGQState::GetPropertyGraph(const string &pg_name) {
+	lock_guard<mutex> guard(property_graph_lock);
 	auto pg_table_entry = registered_property_graphs.find(pg_name);
 	if (pg_table_entry == registered_property_graphs.end()) {
 		throw BinderException("Property graph %s does not exist", pg_name);
@@ -180,6 +185,7 @@ CreatePropertyGraphInfo *DuckPGQState::GetPropertyGraph(const string &pg_name) {
 }
 
 CSR *DuckPGQState::GetCSR(int32_t id) {
+	lock_guard<mutex> guard(csr_lock);
 	auto csr_entry = csr_list.find(id);
 	if (csr_entry == csr_list.end()) {
 		throw ConstraintException("CSR not found with ID %d", id);

--- a/src/duckpgq_state.cpp
+++ b/src/duckpgq_state.cpp
@@ -135,7 +135,7 @@ void DuckPGQState::RegisterPropertyGraph(const shared_ptr<PropertyGraphTable> &t
 	lock_guard<mutex> guard(property_graph_lock);
 	// Ensure the property graph exists in the registry
 	if (registered_property_graphs.find(graph_name) == registered_property_graphs.end()) {
-		registered_property_graphs[graph_name] = make_uniq<CreatePropertyGraphInfo>(graph_name);
+		registered_property_graphs[graph_name] = make_shared_ptr<CreatePropertyGraphInfo>(graph_name);
 	}
 
 	auto &pg_info = registered_property_graphs[graph_name]->Cast<CreatePropertyGraphInfo>();
@@ -175,13 +175,13 @@ void DuckPGQState::QueryEnd() {
 	csr_to_delete.clear();
 }
 
-CreatePropertyGraphInfo *DuckPGQState::GetPropertyGraph(const string &pg_name) {
+shared_ptr<CreatePropertyGraphInfo> DuckPGQState::GetPropertyGraph(const string &pg_name) {
 	lock_guard<mutex> guard(property_graph_lock);
 	auto pg_table_entry = registered_property_graphs.find(pg_name);
 	if (pg_table_entry == registered_property_graphs.end()) {
 		throw BinderException("Property graph %s does not exist", pg_name);
 	}
-	return reinterpret_cast<CreatePropertyGraphInfo *>(pg_table_entry->second.get());
+	return shared_ptr_cast<CreateInfo, CreatePropertyGraphInfo>(pg_table_entry->second);
 }
 
 CSR *DuckPGQState::GetCSR(int32_t id) {

--- a/src/include/duckpgq/core/functions/table/describe_property_graph.hpp
+++ b/src/include/duckpgq/core/functions/table/describe_property_graph.hpp
@@ -24,9 +24,10 @@ public:
 	}
 
 	struct DescribePropertyGraphBindData : public TableFunctionData {
-		explicit DescribePropertyGraphBindData(CreatePropertyGraphInfo *pg_info) : describe_pg_info(pg_info) {
+		explicit DescribePropertyGraphBindData(shared_ptr<CreatePropertyGraphInfo> pg_info)
+		    : describe_pg_info(std::move(pg_info)) {
 		}
-		CreatePropertyGraphInfo *describe_pg_info;
+		shared_ptr<CreatePropertyGraphInfo> describe_pg_info;
 	};
 
 	struct DescribePropertyGraphGlobalData : public GlobalTableFunctionState {

--- a/src/include/duckpgq/core/functions/table/summarize_property_graph.hpp
+++ b/src/include/duckpgq/core/functions/table/summarize_property_graph.hpp
@@ -23,9 +23,10 @@ public:
 	}
 
 	struct SummarizePropertyGraphBindData : public TableFunctionData {
-		explicit SummarizePropertyGraphBindData(CreatePropertyGraphInfo *pg_info) : summarize_pg_info(pg_info) {
+		explicit SummarizePropertyGraphBindData(shared_ptr<CreatePropertyGraphInfo> pg_info)
+		    : summarize_pg_info(std::move(pg_info)) {
 		}
-		CreatePropertyGraphInfo *summarize_pg_info;
+		shared_ptr<CreatePropertyGraphInfo> summarize_pg_info;
 	};
 
 	struct SummarizePropertyGraphGlobalData : public GlobalTableFunctionState {

--- a/src/include/duckpgq/core/utils/duckpgq_utils.hpp
+++ b/src/include/duckpgq/core/utils/duckpgq_utils.hpp
@@ -12,7 +12,8 @@ namespace duckdb {
 
 // Function to get DuckPGQState from ClientContext
 shared_ptr<DuckPGQState> GetDuckPGQState(ClientContext &context, bool throw_error_not_found = false);
-CreatePropertyGraphInfo *GetPropertyGraphInfo(const shared_ptr<DuckPGQState> &duckpgq_state, const string &pg_name);
+shared_ptr<CreatePropertyGraphInfo> GetPropertyGraphInfo(const shared_ptr<DuckPGQState> &duckpgq_state,
+                                                         const string &pg_name);
 shared_ptr<PropertyGraphTable> ValidateSourceNodeAndEdgeTable(CreatePropertyGraphInfo *pg_info,
                                                               const std::string &node_table,
                                                               const std::string &edge_table);

--- a/src/include/duckpgq_state.hpp
+++ b/src/include/duckpgq_state.hpp
@@ -15,7 +15,7 @@ public:
 
 	static void InitializeInternalTable(ClientContext &context);
 	void QueryEnd() override;
-	CreatePropertyGraphInfo *GetPropertyGraph(const string &pg_name);
+	shared_ptr<CreatePropertyGraphInfo> GetPropertyGraph(const string &pg_name);
 	CSR *GetCSR(int32_t id);
 
 	void RetrievePropertyGraphs(const shared_ptr<Connection> &context);
@@ -32,8 +32,8 @@ public:
 	//! Property graphs that are registered. Guarded by property_graph_lock: create/drop
 	//! propagate into every open connection's registry, so a foreign thread can mutate
 	//! this map while its owner reads it.
-	case_insensitive_map_t<unique_ptr<CreateInfo>> registered_property_graphs;
-	mutex property_graph_lock;
+	case_insensitive_map_t<shared_ptr<CreateInfo>> registered_property_graphs;
+	std::mutex property_graph_lock;
 
 	//! Used to build the CSR data structures required for path-finding queries
 	std::unordered_map<int32_t, unique_ptr<CSR>> csr_list;

--- a/src/include/duckpgq_state.hpp
+++ b/src/include/duckpgq_state.hpp
@@ -29,8 +29,11 @@ public:
 	unordered_map<int32_t, unique_ptr<ParsedExpression>> transform_expression;
 	int32_t match_index = 0;
 
-	//! Property graphs that are registered
+	//! Property graphs that are registered. Guarded by property_graph_lock: create/drop
+	//! propagate into every open connection's registry, so a foreign thread can mutate
+	//! this map while its owner reads it.
 	case_insensitive_map_t<unique_ptr<CreateInfo>> registered_property_graphs;
+	mutex property_graph_lock;
 
 	//! Used to build the CSR data structures required for path-finding queries
 	std::unordered_map<int32_t, unique_ptr<CSR>> csr_list;


### PR DESCRIPTION
Three fixes found while integrating duckpgq into SereneDB (statically linked, higher thread counts than stock duckdb), adapted onto current main. Draft: validated inside our integration where the failures reproduce; please let your CI compile-check this base.

1. **CSR arrays sized by count(*) but indexed by rowid** — deleted rows leave rowid gaps, so any rowid at or past the count writes out of bounds in `CsrInitializeVertex/Edge` and corrupts the heap. Reproduced as a SIGABRT in `CSR::~CSR` on a 5-row table with two rows deleted (`DELETE FROM v WHERE id IN (2,3)` then any `ANY SHORTEST`). Both sizing generators (`CSRCountTableSQL`, `DuckPGQSQLCountTable`) now emit `coalesce(max(rowid) + 1, 0)`.

2. **Cross-connection registry race** — `CREATE/DROP PROPERTY GRAPH` propagate into every open connection's `registered_property_graphs` without a lock, so a foreign thread mutates a map while its owner reads it. Under a hardened allocator this aborts (we caught it via absl hash-table debug assertions in the drop propagation within a few suite iterations). Adds `DuckPGQState::property_graph_lock`, taken by all registry accesses; the propagation loops lock the target state one connection at a time. Also makes the create-side loop skip connections without duckpgq state (the drop side already did) instead of forcing state creation onto them.

   **CSR map races** — the path-finding scalar functions read `csr_list` unlocked against the `csr_lock`-guarded creators, including map `operator[]`, which inserts a NULL entry when the id is missing (observed as a sporadic `Attempted to dereference unique_ptr that is NULL` in a shortest-path query), plus one `find()` with no end-check in `CreateCsrEdgeFunction`. All reads go through the locked, throwing `GetCSR`; deletion and the QueryEnd sweep take the lock; the creation functions resolve their entry through the (idempotent, internally locked) initializers.

3. **Registry entries held as `shared_ptr`** — registry values were `unique_ptr`s handed out as raw pointers, so a cross-connection `DROP PROPERTY GRAPH` concurrent with an active bind could free a `CreateInfo` in use. The registry now stores `shared_ptr<CreateInfo>`; `GetPropertyGraph`/`GetPropertyGraphInfo` return `shared_ptr<CreatePropertyGraphInfo>`, and the describe/summarize bind data hold their reference across bind and execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)